### PR TITLE
✨ CRUD for admin on teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following is a list of frameworks, utilities, libraries, components, etc... 
 The following is a list of features this template has
 
 - `/admin` section that holds all crud operations for the application
+  - `/admin/users` CRUD operations for users
+  - `/admin/teams` CRUD operations for teams
 
 ---
 

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -9,7 +9,7 @@ export const schema = gql`
     admin: Boolean!
     updatedAt: DateTime!
     createdAt: DateTime!
-    membership: Membership
+    memberships: [Membership]
   }
 
   type Query {

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -24,6 +24,7 @@ export const schema = gql`
     pronouns: String
     active: Boolean!
     admin: Boolean!
+    teamIds: [String]
   }
 
   input UpdateUserInput {
@@ -33,6 +34,7 @@ export const schema = gql`
     pronouns: String
     active: Boolean
     admin: Boolean
+    teamIds: [String]
   }
 
   type Mutation {

--- a/api/src/services/teams/teams.scenarios.ts
+++ b/api/src/services/teams/teams.scenarios.ts
@@ -2,9 +2,39 @@ import type { Prisma } from '@prisma/client'
 
 export const standard = defineScenario<Prisma.TeamCreateArgs>({
   team: {
-    one: { data: { name: 'String', active: true } },
-    two: { data: { name: 'String', active: true } },
+    one: { data: { name: 'ONE', active: true } },
+    two: { data: { name: 'TWO', active: true } },
   },
 })
 
+export const inUse = {
+  team: {
+    inUseTeam: (): Prisma.TeamCreateArgs => ({
+      data: {
+        name: 'Team1',
+      },
+    }),
+  },
+  user: {
+    user1: (): Prisma.UserCreateArgs => ({
+      data: {
+        email: 'user1@example.com',
+        hashedPassword: 'xxxx',
+        salt: 'pepper',
+      },
+    }),
+  },
+  membership: {
+    membership1: (scenario): Prisma.MembershipCreateArgs => ({
+      data: {
+        teamId: scenario.team.inUseTeam.id,
+        userId: scenario.user.user1.id,
+      },
+    }),
+  },
+}
+
 export type StandardScenario = typeof standard
+export type InUseScenario = {
+  team: Record<string, Prisma.TeamCreateArgs['data']>
+}

--- a/api/src/services/teams/teams.test.ts
+++ b/api/src/services/teams/teams.test.ts
@@ -1,3 +1,5 @@
+import { ValidationError } from '@redwoodjs/graphql-server'
+
 import { createMembership } from '../memberships/memberships'
 import { createUser } from '../users/users'
 
@@ -71,7 +73,7 @@ describe('teams', () => {
         },
       })
       expect(deleteTeam({ id: scenario.team.one.id })).rejects.toThrow(
-        Error('Team is in use, please remove users before deletion')
+        new ValidationError('Please remove users before deleting team')
       )
 
       const result = await team({ id: scenario.team.one.id })

--- a/api/src/services/teams/teams.test.ts
+++ b/api/src/services/teams/teams.test.ts
@@ -1,16 +1,7 @@
 import { ValidationError } from '@redwoodjs/graphql-server'
 
-import { createMembership } from '../memberships/memberships'
-import { createUser } from '../users/users'
-
 import { teams, team, createTeam, updateTeam, deleteTeam } from './teams'
-import type { StandardScenario } from './teams.scenarios'
-
-// Generated boilerplate tests do not account for all circumstances
-// and can fail without adjustments, e.g. Float and DateTime types.
-//           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+import type { InUseScenario, StandardScenario } from './teams.scenarios'
 
 describe('teams', () => {
   scenario('returns all teams', async (scenario: StandardScenario) => {
@@ -58,25 +49,12 @@ describe('teams', () => {
       expect(result).toEqual(null)
     })
 
-    scenario('used', async (scenario: StandardScenario) => {
-      const user = await createUser({
-        input: {
-          active: true,
-          admin: false,
-          email: 'monkey@banana.com',
-        },
-      })
-      await createMembership({
-        input: {
-          teamId: scenario.team.one.id,
-          userId: user.id,
-        },
-      })
-      expect(deleteTeam({ id: scenario.team.one.id })).rejects.toThrow(
+    scenario('inUse', 'used', async (scenario: InUseScenario) => {
+      expect(deleteTeam({ id: scenario.team.inUseTeam.id })).rejects.toThrow(
         new ValidationError('Please remove users before deleting team')
       )
 
-      const result = await team({ id: scenario.team.one.id })
+      const result = await team({ id: scenario.team.inUseTeam.id })
 
       expect(result).not.toEqual(null)
     })

--- a/api/src/services/teams/teams.test.ts
+++ b/api/src/services/teams/teams.test.ts
@@ -47,8 +47,13 @@ describe('teams', () => {
 
   scenario('deletes a team', async (scenario: StandardScenario) => {
     const original = await deleteTeam({ id: scenario.team.one.id })
+    const active = await deleteTeam({
+      id: original.id,
+      input: { name: 'String', active: true, memberships:  },
+    })
     const result = await team({ id: original.id })
 
     expect(result).toEqual(null)
+    expect(result).toEqual(1)
   })
 })

--- a/api/src/services/teams/teams.ts
+++ b/api/src/services/teams/teams.ts
@@ -4,6 +4,8 @@ import type {
   TeamResolvers,
 } from 'types/graphql'
 
+import { ValidationError } from '@redwoodjs/graphql-server'
+
 import { db } from 'src/lib/db'
 
 export const teams: QueryResolvers['teams'] = () => {
@@ -34,7 +36,7 @@ export const deleteTeam: MutationResolvers['deleteTeam'] = async ({ id }) => {
     where: { teamId: id },
   })
   if (membership.length > 0) {
-    throw new Error('Team is in use, please remove users before deletion')
+    throw new ValidationError('Please remove users before deleting team')
   }
 
   return db.team.delete({

--- a/api/src/services/teams/teams.ts
+++ b/api/src/services/teams/teams.ts
@@ -29,10 +29,14 @@ export const updateTeam: MutationResolvers['updateTeam'] = ({ id, input }) => {
   })
 }
 
-export const deleteTeam: MutationResolvers['deleteTeam'] = ({ id }) => {
+export const deleteTeam: MutationResolvers['deleteTeam'] = async ({ id }) => {
   const membership = await db.membership.findMany({
-    where: { teamId: id }
+    where: { teamId: id },
   })
+  if (membership.length > 0) {
+    throw new Error('Team is in use, please remove users before deletion')
+  }
+
   return db.team.delete({
     where: { id },
   })

--- a/api/src/services/teams/teams.ts
+++ b/api/src/services/teams/teams.ts
@@ -30,6 +30,9 @@ export const updateTeam: MutationResolvers['updateTeam'] = ({ id, input }) => {
 }
 
 export const deleteTeam: MutationResolvers['deleteTeam'] = ({ id }) => {
+  const membership = await db.membership.findMany({
+    where: { teamId: id }
+  })
   return db.team.delete({
     where: { id },
   })

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -19,4 +19,42 @@ export const standard = defineScenario<Prisma.UserCreateArgs>({
   },
 })
 
+export const inUse = {
+  team: {
+    team1: (): Prisma.TeamCreateArgs => ({
+      data: {
+        name: 'Team1',
+      },
+    }),
+  },
+  user: {
+    inUseUser: (): Prisma.UserCreateArgs => ({
+      data: {
+        email: 'inUseUser@example.com',
+        hashedPassword: 'xxxx',
+        salt: 'pepper',
+      },
+    }),
+    notInUseUser: (): Prisma.UserCreateArgs => ({
+      data: {
+        email: 'notInUseUser@example.com',
+        hashedPassword: 'xxxx',
+        salt: 'pepper',
+      },
+    }),
+  },
+  membership: {
+    membership1: (scenario): Prisma.MembershipCreateArgs => ({
+      data: {
+        teamId: scenario.team.team1.id,
+        userId: scenario.user.inUseUser.id,
+      },
+    }),
+  },
+}
+
 export type StandardScenario = typeof standard
+export type InUseScenario = {
+  user: Record<string, Prisma.UserCreateArgs['data']>
+  team: Record<string, Prisma.TeamCreateArgs['data']>
+}

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,3 +1,7 @@
+import { db } from 'src/lib/db'
+
+import { createTeam } from '../teams/teams'
+
 import { users, user, createUser, updateUser, deleteUser } from './users'
 import type { StandardScenario } from './users.scenarios'
 
@@ -20,36 +24,130 @@ describe('users', () => {
     expect(result).toEqual(scenario.user.one)
   })
 
-  scenario('creates a user', async () => {
-    const before = new Date()
-    const result = await createUser({
-      input: {
-        active: true,
-        admin: false,
-        email: 'String4652567',
-      },
+  describe('creates', () => {
+    scenario('when no teams', async () => {
+      const before = new Date()
+      const result = await createUser({
+        input: {
+          active: true,
+          admin: false,
+          email: 'String4652567',
+        },
+      })
+
+      expect(result.active).toEqual(true)
+      expect(result.admin).toEqual(false)
+      expect(result.email).toEqual('String4652567')
+      expect(result.hashedPassword).toBeTruthy()
+      expect(result.salt).toBeTruthy()
+      expect(result.createdAt.getTime()).toBeGreaterThan(before.getTime())
+      expect(result.updatedAt.getTime()).toBeGreaterThan(before.getTime())
     })
 
-    expect(result.active).toEqual(true)
-    expect(result.admin).toEqual(false)
-    expect(result.email).toEqual('String4652567')
-    expect(result.hashedPassword).toBeTruthy()
-    expect(result.salt).toBeTruthy()
-    expect(result.createdAt.getTime()).toBeGreaterThan(before.getTime())
-    expect(result.updatedAt.getTime()).toBeGreaterThan(before.getTime())
+    scenario('when adding teams', async () => {
+      const team = await createTeam({
+        input: {
+          active: true,
+          name: 'The Monkeys',
+        },
+      })
+
+      const result = await createUser({
+        input: {
+          active: true,
+          admin: false,
+          email: 'String4652567',
+          teamIds: [team.id],
+        },
+      })
+
+      const membership = await db.membership.findUnique({
+        where: {
+          userTeamConstraint: {
+            teamId: team.id,
+            userId: result.id,
+          },
+        },
+      })
+
+      expect(membership).not.toEqual(null)
+    })
   })
 
-  scenario('updates a user', async (scenario: StandardScenario) => {
-    const original = await user({ id: scenario.user.one.id })
-    const before = new Date()
-    const result = await updateUser({
-      id: original.id,
-      input: { email: 'String61961682' },
+  describe('updates', () => {
+    scenario('when no teams', async (scenario: StandardScenario) => {
+      const original = await user({ id: scenario.user.one.id })
+      const before = new Date()
+      const result = await updateUser({
+        id: original.id,
+        input: { email: 'String61961682' },
+      })
+
+      expect(result.email).toEqual('String61961682')
+      expect(result.createdAt.getTime()).toBeLessThan(before.getTime())
+      expect(result.updatedAt.getTime()).toBeGreaterThan(before.getTime())
     })
 
-    expect(result.email).toEqual('String61961682')
-    expect(result.createdAt.getTime()).toBeLessThan(before.getTime())
-    expect(result.updatedAt.getTime()).toBeGreaterThan(before.getTime())
+    scenario('when adding teams', async (scenario: StandardScenario) => {
+      const team = await createTeam({
+        input: {
+          active: true,
+          name: 'The Monkeys',
+        },
+      })
+
+      const original = await user({ id: scenario.user.one.id })
+
+      const result = await updateUser({
+        id: original.id,
+        input: { teamIds: [team.id] },
+      })
+
+      const membership = await db.membership.findUnique({
+        where: {
+          userTeamConstraint: {
+            teamId: team.id,
+            userId: result.id,
+          },
+        },
+      })
+
+      expect(membership).not.toEqual(null)
+    })
+
+    scenario('when removing teams', async (scenario: StandardScenario) => {
+      const team = await createTeam({
+        input: {
+          active: true,
+          name: 'The Monkeys',
+        },
+      })
+
+      const original = await user({ id: scenario.user.one.id })
+
+      await db.membership.create({
+        data: {
+          teamId: team.id,
+          userId: original.id,
+        },
+      })
+
+      const result = await updateUser({
+        id: original.id,
+        input: { teamIds: [] },
+      })
+
+      const membership = await db.membership.findUnique({
+        where: {
+          userTeamConstraint: {
+            teamId: team.id,
+            userId: result.id,
+          },
+        },
+      })
+
+      expect(membership).toEqual(null)
+    })
   })
 
   scenario('deletes a user', async (scenario: StandardScenario) => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -31,7 +31,7 @@ export const createUser: MutationResolvers['createUser'] = async ({
   const user = await db.user.create({
     data: { ...userInput, salt, hashedPassword },
   })
-  teamIds.forEach(async (teamId) => {
+  teamIds?.forEach(async (teamId) => {
     await db.membership.create({
       data: { teamId, userId: user.id },
     })
@@ -48,7 +48,7 @@ export const updateUser: MutationResolvers['updateUser'] = async ({
     data: { ...userInput },
     where: { id },
   })
-  teamIds.forEach(async (teamId) => {
+  teamIds?.forEach(async (teamId) => {
     await db.membership.upsert({
       where: {
         userTeamConstraint: {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -48,7 +48,7 @@ export const updateUser: MutationResolvers['updateUser'] = async ({
     data: { ...userInput },
     where: { id },
   })
-  teamIds?.forEach(async (teamId) => {
+  for (const teamId of teamIds || []) {
     await db.membership.upsert({
       where: {
         userTeamConstraint: {
@@ -62,7 +62,7 @@ export const updateUser: MutationResolvers['updateUser'] = async ({
       },
       update: {},
     })
-  })
+  }
   await db.membership.deleteMany({
     where: { userId: user.id, NOT: { teamId: { in: teamIds } } },
   })

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -44,6 +44,6 @@ export const deleteUser: MutationResolvers['deleteUser'] = ({ id }) => {
 }
 
 export const User: UserResolvers = {
-  membership: (_obj, { root }) =>
-    db.user.findUnique({ where: { id: root.id } }).membership(),
+  memberships: (_obj, { root }) =>
+    db.membership.findMany({ where: { userId: root.id } }),
 }

--- a/web/src/components/Admin/Team/Teams/Teams.tsx
+++ b/web/src/components/Admin/Team/Teams/Teams.tsx
@@ -65,47 +65,55 @@ const TeamsList = ({ teams }) => {
             <th>Id</th>
             <th>Name</th>
             <th>Active</th>
+            <th>User Count</th>
             <th>Updated at</th>
             <th>Created at</th>
             <th>&nbsp;</th>
           </tr>
         </thead>
         <tbody>
-          {teams.map((team) => (
-            <tr key={team.id}>
-              <td>{truncate(team.id)}</td>
-              <td>{truncate(team.name)}</td>
-              <td>{checkboxInputTag(team.active)}</td>
-              <td>{timeTag(team.updatedAt)}</td>
-              <td>{timeTag(team.createdAt)}</td>
-              <td>
-                <nav className="rw-table-actions">
-                  <Link
-                    to={routes.adminTeam({ id: team.id })}
-                    title={'Show team ' + team.id + ' detail'}
-                    className="rw-button rw-button-small"
-                  >
-                    Show
-                  </Link>
-                  <Link
-                    to={routes.adminEditTeam({ id: team.id })}
-                    title={'Edit team ' + team.id}
-                    className="rw-button rw-button-small rw-button-blue"
-                  >
-                    Edit
-                  </Link>
-                  <button
-                    type="button"
-                    title={'Delete team ' + team.id}
-                    className="rw-button rw-button-small rw-button-red"
-                    onClick={() => onDeleteClick(team.id)}
-                  >
-                    Delete
-                  </button>
-                </nav>
-              </td>
-            </tr>
-          ))}
+          {teams.map((team) => {
+            const userCount = team.memberships.length
+            return (
+              <tr key={team.id}>
+                <td>{truncate(team.id)}</td>
+                <td>{truncate(team.name)}</td>
+                <td>{checkboxInputTag(team.active)}</td>
+                <td>{userCount}</td>
+                <td>{timeTag(team.updatedAt)}</td>
+                <td>{timeTag(team.createdAt)}</td>
+                <td>
+                  <nav className="rw-table-actions">
+                    <Link
+                      to={routes.adminTeam({ id: team.id })}
+                      title={'Show team ' + team.id + ' detail'}
+                      className="rw-button rw-button-small"
+                    >
+                      Show
+                    </Link>
+                    <Link
+                      to={routes.adminEditTeam({ id: team.id })}
+                      title={'Edit team ' + team.id}
+                      className="rw-button rw-button-small rw-button-blue"
+                    >
+                      Edit
+                    </Link>
+                    <button
+                      type="button"
+                      title={'Delete team ' + team.id}
+                      className={`rw-button rw-button-small ${
+                        userCount == 0 && 'rw-button-red'
+                      }`}
+                      onClick={() => onDeleteClick(team.id)}
+                      disabled={userCount > 0}
+                    >
+                      Delete
+                    </button>
+                  </nav>
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/web/src/components/Admin/Team/TeamsCell/TeamsCell.tsx
+++ b/web/src/components/Admin/Team/TeamsCell/TeamsCell.tsx
@@ -13,6 +13,9 @@ export const QUERY = gql`
       active
       updatedAt
       createdAt
+      memberships {
+        id
+      }
     }
   }
 `

--- a/web/src/components/Admin/User/EditUserCell/EditUserCell.tsx
+++ b/web/src/components/Admin/User/EditUserCell/EditUserCell.tsx
@@ -5,7 +5,7 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import UserForm from 'src/components/Admin/User/UserForm'
+import UserFormCell from 'src/components/Admin/User/UserFormCell'
 
 export const QUERY = gql`
   query EditUserById($id: String!) {
@@ -17,6 +17,9 @@ export const QUERY = gql`
       pronouns
       active
       admin
+      memberships {
+        teamId
+      }
     }
   }
 `
@@ -61,7 +64,12 @@ export const Success = ({ user }: CellSuccessProps<EditUserById>) => {
         <h2 className="rw-heading rw-heading-secondary">Edit User {user.id}</h2>
       </header>
       <div className="rw-segment-main">
-        <UserForm user={user} onSave={onSave} error={error} loading={loading} />
+        <UserFormCell
+          user={user}
+          onSave={onSave}
+          error={error}
+          loading={loading}
+        />
       </div>
     </div>
   )

--- a/web/src/components/Admin/User/NewUser/NewUser.tsx
+++ b/web/src/components/Admin/User/NewUser/NewUser.tsx
@@ -2,7 +2,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import UserForm from 'src/components/Admin/User/UserForm'
+import UserFormCell from 'src/components/Admin/User/UserFormCell'
 
 const CREATE_USER_MUTATION = gql`
   mutation CreateUserMutation($input: CreateUserInput!) {
@@ -33,7 +33,7 @@ const NewUser = () => {
         <h2 className="rw-heading rw-heading-secondary">New User</h2>
       </header>
       <div className="rw-segment-main">
-        <UserForm onSave={onSave} loading={loading} error={error} />
+        <UserFormCell onSave={onSave} loading={loading} error={error} />
       </div>
     </div>
   )

--- a/web/src/components/Admin/User/User/User.tsx
+++ b/web/src/components/Admin/User/User/User.tsx
@@ -80,6 +80,14 @@ const User = ({ user }) => {
               <td>{checkboxInputTag(user.admin)}</td>
             </tr>
             <tr>
+              <th>Teams</th>
+              <td>
+                {user.memberships
+                  ?.map((membership) => membership.team.name)
+                  .join(', ')}
+              </td>
+            </tr>
+            <tr>
               <th>Updated at</th>
               <td>{timeTag(user.updatedAt)}</td>
             </tr>

--- a/web/src/components/Admin/User/UserCell/UserCell.tsx
+++ b/web/src/components/Admin/User/UserCell/UserCell.tsx
@@ -16,6 +16,11 @@ export const QUERY = gql`
       admin
       updatedAt
       createdAt
+      memberships {
+        team {
+          name
+        }
+      }
     }
   }
 `

--- a/web/src/components/Admin/User/UserForm/UserForm.tsx
+++ b/web/src/components/Admin/User/UserForm/UserForm.tsx
@@ -128,7 +128,7 @@ const UserForm = (props) => {
         <FieldError name="admin" className="rw-field-error" />
 
         <Label
-          name="team"
+          name="teamIds"
           className="rw-label"
           errorClassName="rw-label rw-label-error"
         >
@@ -136,7 +136,7 @@ const UserForm = (props) => {
         </Label>
 
         <SelectField
-          name="team"
+          name="teamIds"
           className="rw-input"
           errorClassName="rw-input rw-input-error"
           multiple={true}
@@ -154,7 +154,7 @@ const UserForm = (props) => {
           ))}
         </SelectField>
 
-        <FieldError name="team" className="rw-field-error" />
+        <FieldError name="teamIds" className="rw-field-error" />
 
         <div className="rw-button-group">
           <Submit disabled={props.loading} className="rw-button rw-button-blue">

--- a/web/src/components/Admin/User/UserForm/UserForm.tsx
+++ b/web/src/components/Admin/User/UserForm/UserForm.tsx
@@ -6,6 +6,7 @@ import {
   TextField,
   CheckboxField,
   Submit,
+  SelectField,
 } from '@redwoodjs/forms'
 
 const UserForm = (props) => {
@@ -125,6 +126,35 @@ const UserForm = (props) => {
         />
 
         <FieldError name="admin" className="rw-field-error" />
+
+        <Label
+          name="team"
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
+        >
+          Team
+        </Label>
+
+        <SelectField
+          name="team"
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
+          multiple={true}
+        >
+          {props.teams?.map((team) => (
+            <option
+              key={team.id}
+              value={team.id}
+              selected={props.user?.memberships?.some(
+                (membership) => membership.teamId == team.id
+              )}
+            >
+              {team.name}
+            </option>
+          ))}
+        </SelectField>
+
+        <FieldError name="team" className="rw-field-error" />
 
         <div className="rw-button-group">
           <Submit disabled={props.loading} className="rw-button rw-button-blue">

--- a/web/src/components/Admin/User/UserFormCell/UserFormCell.tsx
+++ b/web/src/components/Admin/User/UserFormCell/UserFormCell.tsx
@@ -1,0 +1,20 @@
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+
+import UserForm from 'src/components/Admin/User/UserForm'
+
+export const QUERY = gql`
+  query UserFormTeams {
+    teams {
+      id
+      name
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Failure = ({ error }: CellFailureProps) => (
+  <div className="rw-cell-error">{error.message}</div>
+)
+
+export const Success = (props: CellSuccessProps) => <UserForm {...props} />


### PR DESCRIPTION
# Pull Request

## Story

Fix #30

## Description

- [x] Remove ability to delete a team unless there are no users assigned
- [x] Ability to assign a user to a team

## Screenshots

Can't delete if users are assigned:
<img width="1763" alt="Screen Shot 2022-08-26 at 4 32 37 PM" src="https://user-images.githubusercontent.com/2641685/186986410-dd98e3d0-59f2-4e45-8d87-bdeac2f35854.png">

Assign team to a user:
<img width="1770" alt="Screen Shot 2022-08-26 at 4 38 36 PM" src="https://user-images.githubusercontent.com/2641685/186987200-9d5e05f7-f3e6-465e-b184-b70137db02d9.png">

## Affected Areas

Users and team administration

## Tests

Tests to make sure API follows UI

## Was this feature tested on all browsers?

- [x] Chrome

## Definition of Done

- [x] README updated
- [x] Tests written
- [x] Acceptance criteria implement
- [x] Code reviewed
- [x] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![team](https://media.giphy.com/media/xUPGcjQ6dJEjH5uwMw/giphy-downsized.gif)
