### PR TITLE
Ignore web/types when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 api/types/*
+web/types/*
 ./index.js
 .vscode
 tmp


### PR DESCRIPTION
Running: `yarn eslint` would result in

```
    227 problems (0 errors, 227 warnings)
```

Types are autogenerated by redwood
