### PR TITLE
✨ Feature/35 admin user roles

### DIFF
--- a/api/db/migrations/20220901102628_add_cascade_delete_to_membership_role_for_memberships/migration.sql
+++ b/api/db/migrations/20220901102628_add_cascade_delete_to_membership_role_for_memberships/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "MembershipRole" DROP CONSTRAINT "MembershipRole_membershipId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "MembershipRole" ADD CONSTRAINT "MembershipRole_membershipId_fkey" FOREIGN KEY ("membershipId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/db/migrations/20220901133707_unique_constraint_for_membership_and_role_on_membership_role/migration.sql
+++ b/api/db/migrations/20220901133707_unique_constraint_for_membership_and_role_on_membership_role/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[membershipId,roleId]` on the table `MembershipRole` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "MembershipRole_membershipId_roleId_key" ON "MembershipRole"("membershipId", "roleId");

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -47,10 +47,12 @@ model Team {
 
 model MembershipRole {
   id           String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  membership   Membership @relation(fields: [membershipId], references: [id])
+  membership   Membership @relation(fields: [membershipId], references: [id], onDelete: Cascade)
   membershipId String     @db.Uuid
   role         Role       @relation(fields: [roleId], references: [id])
   roleId       String     @db.Uuid
+
+  @@unique([membershipId, roleId], name: "membershipRoleConstraint")
 }
 
 model Role {

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -25,6 +25,7 @@ export const schema = gql`
     active: Boolean!
     admin: Boolean!
     teamIds: [String]
+    roleIds: [String]
   }
 
   input UpdateUserInput {
@@ -35,6 +36,7 @@ export const schema = gql`
     active: Boolean
     admin: Boolean
     teamIds: [String]
+    roleIds: [String]
   }
 
   type Mutation {

--- a/api/src/services/membershipRoles/membershipRoles.test.ts
+++ b/api/src/services/membershipRoles/membershipRoles.test.ts
@@ -37,13 +37,13 @@ describe('membershipRoles', () => {
   scenario('creates a membershipRole', async (scenario: StandardScenario) => {
     const result = await createMembershipRole({
       input: {
-        membershipId: scenario.membershipRole.two.membershipId,
+        membershipId: scenario.membershipRole.one.membershipId,
         roleId: scenario.membershipRole.two.roleId,
       },
     })
 
     expect(result.membershipId).toEqual(
-      scenario.membershipRole.two.membershipId
+      scenario.membershipRole.one.membershipId
     )
     expect(result.roleId).toEqual(scenario.membershipRole.two.roleId)
   })

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -1,25 +1,35 @@
-import type { Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
+
+const DEFAULT_FIELDS = {
+  hashedPassword: 'xxxx',
+  salt: 'pepper',
+}
 
 export const standard = defineScenario<Prisma.UserCreateArgs>({
   user: {
     one: {
       data: {
         email: 'String4589593',
-        hashedPassword: 'String',
-        salt: 'String',
+        ...DEFAULT_FIELDS,
       },
     },
     two: {
       data: {
         email: 'String1300967',
-        hashedPassword: 'String',
-        salt: 'String',
+        ...DEFAULT_FIELDS,
       },
     },
   },
 })
 
-export const inUse = {
+export const associations = {
+  role: {
+    role1: (): Prisma.RoleCreateArgs => ({
+      data: {
+        name: 'Role1',
+      },
+    }),
+  },
   team: {
     team1: (): Prisma.TeamCreateArgs => ({
       data: {
@@ -28,16 +38,15 @@ export const inUse = {
     }),
   },
   user: {
-    inUseUser: (): Prisma.UserCreateArgs => ({
+    teamUser: (): Prisma.UserCreateArgs => ({
       data: {
-        email: 'inUseUser@example.com',
-        hashedPassword: 'xxxx',
-        salt: 'pepper',
+        email: 'teamUser@example.com',
+        ...DEFAULT_FIELDS,
       },
     }),
-    notInUseUser: (): Prisma.UserCreateArgs => ({
+    noTeamUser: (): Prisma.UserCreateArgs => ({
       data: {
-        email: 'notInUseUser@example.com',
+        email: 'noTeamUser@example.com',
         hashedPassword: 'xxxx',
         salt: 'pepper',
       },
@@ -47,14 +56,23 @@ export const inUse = {
     membership1: (scenario): Prisma.MembershipCreateArgs => ({
       data: {
         teamId: scenario.team.team1.id,
-        userId: scenario.user.inUseUser.id,
+        userId: scenario.user.teamUser.id,
+      },
+    }),
+  },
+  membershipRole: {
+    membershipRole1: (scenario): Prisma.MembershipRoleCreateArgs => ({
+      data: {
+        membershipId: scenario.membership.membership1.id,
+        roleId: scenario.role.role1.id,
       },
     }),
   },
 }
 
 export type StandardScenario = typeof standard
-export type InUseScenario = {
-  user: Record<string, Prisma.UserCreateArgs['data']>
+export type AssociationsScenario = {
+  role: Record<string, Prisma.RoleCreateArgs['data']>
   team: Record<string, Prisma.TeamCreateArgs['data']>
+  user: Record<string, Prisma.UserCreateArgs['data']>
 }

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -47,8 +47,7 @@ export const associations = {
     noTeamUser: (): Prisma.UserCreateArgs => ({
       data: {
         email: 'noTeamUser@example.com',
-        hashedPassword: 'xxxx',
-        salt: 'pepper',
+        ...DEFAULT_FIELDS,
       },
     }),
   },

--- a/web/src/components/Admin/User/EditUserCell/EditUserCell.tsx
+++ b/web/src/components/Admin/User/EditUserCell/EditUserCell.tsx
@@ -5,7 +5,7 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import UserFormCell from 'src/components/Admin/User/UserFormCell'
+import UserForm from '../UserForm'
 
 export const QUERY = gql`
   query EditUserById($id: String!) {
@@ -19,6 +19,9 @@ export const QUERY = gql`
       admin
       memberships {
         teamId
+        membershipRoles {
+          roleId
+        }
       }
     }
   }
@@ -66,12 +69,7 @@ export const Success = ({ user }: CellSuccessProps<EditUserById>) => {
         <h2 className="rw-heading rw-heading-secondary">Edit User {user.id}</h2>
       </header>
       <div className="rw-segment-main">
-        <UserFormCell
-          user={user}
-          onSave={onSave}
-          error={error}
-          loading={loading}
-        />
+        <UserForm user={user} onSave={onSave} error={error} loading={loading} />
       </div>
     </div>
   )

--- a/web/src/components/Admin/User/EditUserCell/EditUserCell.tsx
+++ b/web/src/components/Admin/User/EditUserCell/EditUserCell.tsx
@@ -52,6 +52,8 @@ export const Success = ({ user }: CellSuccessProps<EditUserById>) => {
     onError: (error) => {
       toast.error(error.message)
     },
+    refetchQueries: [{ query: QUERY, variables: { id: user.id } }],
+    awaitRefetchQueries: true,
   })
 
   const onSave = (input, id) => {

--- a/web/src/components/Admin/User/NewUser/NewUser.tsx
+++ b/web/src/components/Admin/User/NewUser/NewUser.tsx
@@ -2,7 +2,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import UserFormCell from 'src/components/Admin/User/UserFormCell'
+import UserForm from '../UserForm'
 
 const CREATE_USER_MUTATION = gql`
   mutation CreateUserMutation($input: CreateUserInput!) {
@@ -33,7 +33,7 @@ const NewUser = () => {
         <h2 className="rw-heading rw-heading-secondary">New User</h2>
       </header>
       <div className="rw-segment-main">
-        <UserFormCell onSave={onSave} loading={loading} error={error} />
+        <UserForm onSave={onSave} loading={loading} error={error} />
       </div>
     </div>
   )

--- a/web/src/components/Admin/User/UserForm/UserForm.tsx
+++ b/web/src/components/Admin/User/UserForm/UserForm.tsx
@@ -19,7 +19,7 @@ const UserForm = (props) => {
     props.onSave(data, props.user?.id)
   }
 
-  const roleName = (teamId, roleId) => `${teamId}-${roleId}`
+  const roleName = (teamId, roleId) => `${teamId},${roleId}`
 
   return (
     <div className="rw-form-wrapper">

--- a/web/src/components/Admin/User/UserForm/UserForm.tsx
+++ b/web/src/components/Admin/User/UserForm/UserForm.tsx
@@ -6,24 +6,32 @@ import {
   TextField,
   CheckboxField,
   Submit,
-  useForm,
 } from '@redwoodjs/forms'
 
 import UserFormTeamsCell from '../UserFormTeamsCell'
 
 const UserForm = (props) => {
-  const formMethods = useForm()
-  const { setValue } = formMethods
-
   const onSubmit = (data) => {
     props.onSave(data, props.user?.id)
   }
 
-  const roleName = (teamId, roleId) => `${teamId},${roleId}`
+  const roleValue = (teamId, roleId) => `${teamId},${roleId}`
+
+  const roleIds = (props.user?.memberships || [])
+    .map((membership) =>
+      (membership?.membershipRoles || []).map((membershipRole) =>
+        roleValue(membership.teamId, membershipRole.roleId)
+      )
+    )
+    .flat()
+
+  const teamIds = (props.user?.memberships || []).map(
+    (membership) => membership.teamId
+  )
 
   return (
     <div className="rw-form-wrapper">
-      <Form formMethods={formMethods} onSubmit={onSubmit} error={props.error}>
+      <Form onSubmit={onSubmit} error={props.error}>
         <FormError
           error={props.error}
           wrapperClassName="rw-form-error-wrapper"
@@ -135,18 +143,9 @@ const UserForm = (props) => {
         <FieldError name="admin" className="rw-field-error" />
 
         <UserFormTeamsCell
-          roleIds={(props.user?.memberships || [])
-            .map((membership) =>
-              (membership?.membershipRoles || []).map((membershipRole) =>
-                roleName(membership.teamId, membershipRole.roleId)
-              )
-            )
-            .flat()}
-          roleName={roleName}
-          setValue={setValue}
-          teamIds={(props.user?.memberships || []).map(
-            (membership) => membership.teamId
-          )}
+          roleIds={roleIds}
+          roleValue={roleValue}
+          teamIds={teamIds}
         />
 
         <div className="rw-button-group">

--- a/web/src/components/Admin/User/UserForm/UserForm.tsx
+++ b/web/src/components/Admin/User/UserForm/UserForm.tsx
@@ -9,7 +9,7 @@ import {
   useForm,
 } from '@redwoodjs/forms'
 
-import { UserTeams } from './UserTeams'
+import UserFormTeamsCell from '../UserFormTeamsCell'
 
 const UserForm = (props) => {
   const formMethods = useForm()
@@ -18,6 +18,8 @@ const UserForm = (props) => {
   const onSubmit = (data) => {
     props.onSave(data, props.user?.id)
   }
+
+  const roleName = (teamId, roleId) => `${teamId}-${roleId}`
 
   return (
     <div className="rw-form-wrapper">
@@ -132,12 +134,19 @@ const UserForm = (props) => {
 
         <FieldError name="admin" className="rw-field-error" />
 
-        <UserTeams
-          originalTeamIds={(props.user?.memberships || []).map(
+        <UserFormTeamsCell
+          roleIds={(props.user?.memberships || [])
+            .map((membership) =>
+              (membership?.membershipRoles || []).map((membershipRole) =>
+                roleName(membership.teamId, membershipRole.roleId)
+              )
+            )
+            .flat()}
+          roleName={roleName}
+          setValue={setValue}
+          teamIds={(props.user?.memberships || []).map(
             (membership) => membership.teamId
           )}
-          setValue={setValue}
-          teams={props.teams}
         />
 
         <div className="rw-button-group">

--- a/web/src/components/Admin/User/UserForm/UserForm.tsx
+++ b/web/src/components/Admin/User/UserForm/UserForm.tsx
@@ -6,17 +6,22 @@ import {
   TextField,
   CheckboxField,
   Submit,
-  SelectField,
+  useForm,
 } from '@redwoodjs/forms'
 
+import { UserTeams } from './UserTeams'
+
 const UserForm = (props) => {
+  const formMethods = useForm()
+  const { setValue } = formMethods
+
   const onSubmit = (data) => {
-    props.onSave(data, props?.user?.id)
+    props.onSave(data, props.user?.id)
   }
 
   return (
     <div className="rw-form-wrapper">
-      <Form onSubmit={onSubmit} error={props.error}>
+      <Form formMethods={formMethods} onSubmit={onSubmit} error={props.error}>
         <FormError
           error={props.error}
           wrapperClassName="rw-form-error-wrapper"
@@ -127,34 +132,13 @@ const UserForm = (props) => {
 
         <FieldError name="admin" className="rw-field-error" />
 
-        <Label
-          name="teamIds"
-          className="rw-label"
-          errorClassName="rw-label rw-label-error"
-        >
-          Team
-        </Label>
-
-        <SelectField
-          name="teamIds"
-          className="rw-input"
-          errorClassName="rw-input rw-input-error"
-          multiple={true}
-        >
-          {props.teams?.map((team) => (
-            <option
-              key={team.id}
-              value={team.id}
-              selected={props.user?.memberships?.some(
-                (membership) => membership.teamId == team.id
-              )}
-            >
-              {team.name}
-            </option>
-          ))}
-        </SelectField>
-
-        <FieldError name="teamIds" className="rw-field-error" />
+        <UserTeams
+          originalTeamIds={(props.user?.memberships || []).map(
+            (membership) => membership.teamId
+          )}
+          setValue={setValue}
+          teams={props.teams}
+        />
 
         <div className="rw-button-group">
           <Submit disabled={props.loading} className="rw-button rw-button-blue">

--- a/web/src/components/Admin/User/UserForm/UserTeams.tsx
+++ b/web/src/components/Admin/User/UserForm/UserTeams.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useReducer, useState } from 'react'
+
+import { HiddenField } from '@redwoodjs/forms'
+
+const partition = (teams, selectedTeamIds) =>
+  teams.reduce(
+    (partitioned, team) => {
+      return selectedTeamIds.includes(team.id)
+        ? {
+            ...partitioned,
+            selectedTeams: [...partitioned.selectedTeams, team],
+          }
+        : {
+            ...partitioned,
+            unselectedTeams: [...partitioned.unselectedTeams, team],
+          }
+    },
+    { selectedTeams: [], unselectedTeams: [] }
+  )
+
+const UserTeams = ({ originalTeamIds, setValue, teams }) => {
+  const [teamToAdd, setTeamToAdd] = useState(null)
+  const [state, dispatch] = useReducer(
+    (state, action) => {
+      const teamIds = (() => {
+        switch (action.type) {
+          case 'select':
+            return [...state.teamIds, action.id]
+          case 'unselect':
+            return state.teamIds.filter((teamId) => teamId !== action.id)
+          default:
+            return state.teamIds
+        }
+      })()
+
+      return {
+        ...partition(teams, teamIds),
+        teamIds,
+      }
+    },
+    {
+      ...partition(teams, originalTeamIds),
+      teamIds: originalTeamIds,
+    }
+  )
+
+  useEffect(() => {
+    setValue('teamIds', state.teamIds)
+  }, [setValue, state])
+
+  const addTeam = (e) => {
+    dispatch({ type: 'select', id: teamToAdd })
+    e.preventDefault()
+  }
+
+  const removeTeam = (e) => {
+    dispatch({ type: 'unselect', id: e.target.value })
+    e.preventDefault()
+  }
+
+  return (
+    <>
+      <div className="rw-label">Teams</div>
+      <HiddenField name="teamIds" />
+      <table className="rw-table">
+        <tbody>
+          <tr>
+            <td>
+              <select
+                name="addTeam"
+                onChange={(e) => setTeamToAdd(e.target.value)}
+              >
+                <option>Select a Team to Add</option>
+                {(state.unselectedTeams || []).map((team) => (
+                  <option key={team.id} value={team.id}>
+                    {team.name}
+                  </option>
+                ))}
+              </select>
+            </td>
+            <td>
+              <button
+                className={`rw-button rw-button-small ${
+                  !!teamToAdd && 'rw-button-blue'
+                }`}
+                onClick={addTeam}
+                title={'Add Team'}
+                disabled={!teamToAdd}
+              >
+                Add Team
+              </button>
+            </td>
+          </tr>
+          {(state.selectedTeams || []).map((team) => (
+            <tr key={team.id}>
+              <td>{team.name}</td>
+              <td>
+                <button
+                  className="rw-button rw-button-small rw-button-red"
+                  onClick={removeTeam}
+                  title={'Remove Team ' + team.name}
+                  value={team.id}
+                >
+                  Remove Team
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  )
+}
+
+export { UserTeams }

--- a/web/src/components/Admin/User/UserFormTeams/UserFormTeams.tsx
+++ b/web/src/components/Admin/User/UserFormTeams/UserFormTeams.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useReducer, useState } from 'react'
 
-import { HiddenField } from '@redwoodjs/forms'
+import { CheckboxField, HiddenField } from '@redwoodjs/forms'
 
 const partition = (teams, selectedTeamIds) =>
   teams.reduce(
-    (partitioned, team) => {
-      return selectedTeamIds.includes(team.id)
+    (partitioned, team) =>
+      selectedTeamIds.includes(team.id)
         ? {
             ...partitioned,
             selectedTeams: [...partitioned.selectedTeams, team],
@@ -13,16 +13,22 @@ const partition = (teams, selectedTeamIds) =>
         : {
             ...partitioned,
             unselectedTeams: [...partitioned.unselectedTeams, team],
-          }
-    },
+          },
     { selectedTeams: [], unselectedTeams: [] }
   )
 
-const UserTeams = ({ originalTeamIds, setValue, teams }) => {
+const UserFormTeams = ({
+  roleIds,
+  roleName,
+  roles,
+  setValue,
+  teamIds,
+  teams,
+}) => {
   const [teamToAdd, setTeamToAdd] = useState(null)
   const [state, dispatch] = useReducer(
     (state, action) => {
-      const teamIds = (() => {
+      const newTeamIds = (() => {
         switch (action.type) {
           case 'select':
             return [...state.teamIds, action.id]
@@ -34,13 +40,13 @@ const UserTeams = ({ originalTeamIds, setValue, teams }) => {
       })()
 
       return {
-        ...partition(teams, teamIds),
-        teamIds,
+        ...partition(teams, newTeamIds),
+        teamIds: newTeamIds,
       }
     },
     {
-      ...partition(teams, originalTeamIds),
-      teamIds: originalTeamIds,
+      ...partition(teams, teamIds),
+      teamIds,
     }
   )
 
@@ -62,38 +68,53 @@ const UserTeams = ({ originalTeamIds, setValue, teams }) => {
     <>
       <div className="rw-label">Teams</div>
       <HiddenField name="teamIds" />
+      <div className="flex">
+        <select name="addTeam" onChange={(e) => setTeamToAdd(e.target.value)}>
+          <option>Select a Team to Add</option>
+          {(state.unselectedTeams || []).map((team) => (
+            <option key={team.id} value={team.id}>
+              {team.name}
+            </option>
+          ))}
+        </select>
+        <button
+          className={`rw-button rw-button-small ${
+            !!teamToAdd && 'rw-button-green'
+          }`}
+          onClick={addTeam}
+          title={'Add Team'}
+          disabled={!teamToAdd}
+        >
+          Add Team
+        </button>
+      </div>
       <table className="rw-table">
-        <tbody>
+        <thead>
           <tr>
-            <td>
-              <select
-                name="addTeam"
-                onChange={(e) => setTeamToAdd(e.target.value)}
-              >
-                <option>Select a Team to Add</option>
-                {(state.unselectedTeams || []).map((team) => (
-                  <option key={team.id} value={team.id}>
-                    {team.name}
-                  </option>
-                ))}
-              </select>
-            </td>
-            <td>
-              <button
-                className={`rw-button rw-button-small ${
-                  !!teamToAdd && 'rw-button-blue'
-                }`}
-                onClick={addTeam}
-                title={'Add Team'}
-                disabled={!teamToAdd}
-              >
-                Add Team
-              </button>
-            </td>
+            <th>Team</th>
+            <th>Roles</th>
+            <th>&nbsp;</th>
           </tr>
+        </thead>
+        <tbody>
           {(state.selectedTeams || []).map((team) => (
             <tr key={team.id}>
               <td>{team.name}</td>
+              <td>
+                {(roles || []).map((role) => {
+                  const name = roleName(team.id, role.id)
+                  return (
+                    <label key={role.id} htmlFor={name} className="rw-label">
+                      <CheckboxField
+                        name={name}
+                        className="rw-input"
+                        checked={roleIds.includes(name)}
+                      />
+                      {role.name}
+                    </label>
+                  )
+                })}
+              </td>
               <td>
                 <button
                   className="rw-button rw-button-small rw-button-red"
@@ -112,4 +133,4 @@ const UserTeams = ({ originalTeamIds, setValue, teams }) => {
   )
 }
 
-export { UserTeams }
+export { UserFormTeams }

--- a/web/src/components/Admin/User/UserFormTeams/UserFormTeams.tsx
+++ b/web/src/components/Admin/User/UserFormTeams/UserFormTeams.tsx
@@ -106,9 +106,10 @@ const UserFormTeams = ({
                   return (
                     <label key={role.id} htmlFor={name} className="rw-label">
                       <CheckboxField
-                        name={name}
+                        name="roleIds"
                         className="rw-input"
-                        checked={roleIds.includes(name)}
+                        defaultChecked={roleIds.includes(name)}
+                        value={name}
                       />
                       {role.name}
                     </label>

--- a/web/src/components/Admin/User/UserFormTeams/useTeamState.test.ts
+++ b/web/src/components/Admin/User/UserFormTeams/useTeamState.test.ts
@@ -1,0 +1,88 @@
+import { act } from 'react-dom/test-utils'
+
+import { useFormContext } from '@redwoodjs/forms'
+import { renderHook } from '@redwoodjs/testing/web'
+
+import { useTeamState } from './useTeamState'
+
+jest.mock('@redwoodjs/forms', () => ({
+  useFormContext: jest.fn().mockImplementation(() => ({ setValue: jest.fn() })),
+}))
+
+const mockUseFormContext = useFormContext as jest.Mock
+
+describe('useTeamState', () => {
+  const id1 = 'monkey1'
+  const id2 = 'monkey2'
+  const id3 = 'monkey3'
+  const teams = [
+    {
+      id: id1,
+    },
+    {
+      id: id2,
+    },
+    {
+      id: id3,
+    },
+  ]
+  const teamIds = [id1, id2]
+
+  beforeEach(() => {
+    mockUseFormContext.mockClear()
+  })
+
+  it('renders successfully', () => {
+    const { result } = renderHook(() =>
+      useTeamState({ initialTeamIds: teamIds, teams })
+    )
+    expect(result.error).toBe(undefined)
+  })
+
+  it('sets initial state', () => {
+    const {
+      result: {
+        current: { state },
+      },
+    } = renderHook(() => useTeamState({ initialTeamIds: teamIds, teams }))
+
+    expect(state.teamToAdd).toBe(null)
+    expect(state.teamIds).toEqual(teamIds)
+    expect(state.selectedTeams).toEqual([{ id: id1 }, { id: id2 }])
+    expect(state.unselectedTeams).toEqual([{ id: id3 }])
+  })
+
+  it('selects a team', () => {
+    const event = { preventDefault: jest.fn() }
+    const { result } = renderHook(() =>
+      useTeamState({ initialTeamIds: teamIds, teams })
+    )
+
+    act(() => {
+      result.current.dispatch({ type: 'ADD_TEAM', id: id3 })
+    })
+    expect(result.current.state.teamToAdd).toEqual(id3)
+    act(() => {
+      result.current.addTeam(event)
+    })
+    expect(result.current.state.teamIds).toEqual([id1, id2, id3])
+    expect(result.current.state.selectedTeams).toEqual([
+      { id: id1 },
+      { id: id2 },
+      { id: id3 },
+    ])
+  })
+
+  it('removes a team', () => {
+    const event = { preventDefault: jest.fn(), target: { value: id2 } }
+    const { result } = renderHook(() =>
+      useTeamState({ initialTeamIds: teamIds, teams })
+    )
+
+    act(() => {
+      result.current.removeTeam(event)
+    })
+    expect(result.current.state.teamIds).toEqual([id1])
+    expect(result.current.state.selectedTeams).toEqual([{ id: id1 }])
+  })
+})

--- a/web/src/components/Admin/User/UserFormTeams/useTeamState.ts
+++ b/web/src/components/Admin/User/UserFormTeams/useTeamState.ts
@@ -1,0 +1,68 @@
+import { useEffect, useReducer } from 'react'
+
+import { useFormContext } from '@redwoodjs/forms'
+
+const partition = (teams, selectedTeamIds) =>
+  teams.reduce(
+    (partitioned, team) =>
+      selectedTeamIds.includes(team.id)
+        ? {
+            ...partitioned,
+            selectedTeams: [...partitioned.selectedTeams, team],
+          }
+        : {
+            ...partitioned,
+            unselectedTeams: [...partitioned.unselectedTeams, team],
+          },
+    { selectedTeams: [], unselectedTeams: [] }
+  )
+
+type StateActionType = 'SELECT' | 'UNSELECT' | 'ADD_TEAM'
+
+const reducer =
+  (teams) => (state, action: { id: string; type: StateActionType }) => {
+    const newTeamIds = (() => {
+      switch (action.type) {
+        case 'SELECT':
+          return [...state.teamIds, action.id]
+        case 'UNSELECT':
+          return state.teamIds.filter((teamId) => teamId !== action.id)
+        default:
+          return state.teamIds
+      }
+    })()
+
+    return {
+      ...partition(teams, newTeamIds),
+      teamIds: newTeamIds,
+      teamToAdd: action.type === 'ADD_TEAM' ? action.id : state.teamToAdd,
+    }
+  }
+
+const useTeamState = ({ initialTeamIds, teams }) => {
+  const { setValue } = useFormContext()
+  const [state, dispatch] = useReducer(reducer(teams), {
+    ...partition(teams, initialTeamIds),
+    teamIds: initialTeamIds,
+    teamToAdd: null,
+  })
+
+  useEffect(() => {
+    setValue('teamIds', state.teamIds)
+  }, [setValue, state])
+
+  const addTeam = (e) => {
+    dispatch({ type: 'SELECT', id: state.teamToAdd })
+    dispatch({ type: 'ADD_TEAM', id: null })
+    e.preventDefault()
+  }
+
+  const removeTeam = (e) => {
+    dispatch({ type: 'UNSELECT', id: e.target.value })
+    e.preventDefault()
+  }
+
+  return { addTeam, dispatch, removeTeam, state }
+}
+
+export { useTeamState }

--- a/web/src/components/Admin/User/UserFormTeamsCell/UserFormTeamsCell.tsx
+++ b/web/src/components/Admin/User/UserFormTeamsCell/UserFormTeamsCell.tsx
@@ -1,10 +1,14 @@
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
-import UserForm from 'src/components/Admin/User/UserForm'
+import { UserFormTeams } from '../UserFormTeams'
 
 export const QUERY = gql`
   query UserFormTeams {
     teams {
+      id
+      name
+    }
+    roles {
       id
       name
     }
@@ -17,4 +21,4 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div className="rw-cell-error">{error.message}</div>
 )
 
-export const Success = (props: CellSuccessProps) => <UserForm {...props} />
+export const Success = (props: CellSuccessProps) => <UserFormTeams {...props} />


### PR DESCRIPTION
# Pull Request

Fix #35 

## Description

Adds ability to assign roles per team on a user

## Solution

Added some new constraints to the DB to support foreign keys, combined keys, and cascade deletes. Changed selection of teams to be more of a table like an index page.

## Screenshots

<img width="1289" alt="Screen Shot 2022-09-01 at 9 58 56 AM" src="https://user-images.githubusercontent.com/2641685/187932659-8790b616-e13a-4549-9b38-4b90b16a3df4.png">

## Affected Areas

User admin

## Tests

Tests the API to verify that it can receive roleIds and then create the associated records.

## Was this feature tested on all browsers?

- [x] Chrome

## Definition of Done

- [x] Tests written
- [x] Acceptance criteria implement
- [x] Code reviewed
- [x] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![roles](https://media.giphy.com/media/lcySndwSDLxC4eOU86/giphy.gif)
