### PR TITLE
✨ Feature/34 admin user remove

### DIFF
--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -44,6 +44,6 @@ export const schema = gql`
       @requireAuth(roles: ["super admin"])
     updateUser(id: String!, input: UpdateUserInput!): User!
       @requireAuth(roles: ["super admin"])
-    deleteUser(id: String!): User! @requireAuth(roles: ["super admin"])
+    removeUser(id: String!): User! @requireAuth(roles: ["super admin"])
   }
 `

--- a/api/src/services/roles/roles.test.ts
+++ b/api/src/services/roles/roles.test.ts
@@ -21,8 +21,8 @@ describe('roles', () => {
     })
 
     expect(result.name).toEqual('NEW-role')
-    expect(result.createdAt.getTime()).toBeGreaterThan(before.getTime())
-    expect(result.updatedAt.getTime()).toBeGreaterThan(before.getTime())
+    expect(result.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
+    expect(result.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
   })
 
   scenario('updates a role', async (scenario: StandardScenario) => {

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,6 +1,6 @@
 import { db } from 'src/lib/db'
 
-import { users, user, createUser, updateUser, deleteUser } from './users'
+import { users, user, createUser, updateUser, removeUser } from './users'
 import type { AssociationsScenario, StandardScenario } from './users.scenarios'
 
 describe('users', () => {
@@ -32,8 +32,12 @@ describe('users', () => {
       expect(result.email).toEqual('String4652567')
       expect(result.hashedPassword).toBeTruthy()
       expect(result.salt).toBeTruthy()
-      expect(result.createdAt.getTime()).toBeGreaterThan(before.getTime())
-      expect(result.updatedAt.getTime()).toBeGreaterThan(before.getTime())
+      expect(result.createdAt.getTime()).toBeGreaterThanOrEqual(
+        before.getTime()
+      )
+      expect(result.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        before.getTime()
+      )
     })
 
     scenario(
@@ -171,10 +175,16 @@ describe('users', () => {
     )
   })
 
-  scenario('deletes a user', async (scenario: StandardScenario) => {
-    const original = await deleteUser({ id: scenario.user.one.id })
-    const result = await user({ id: original.id })
-
-    expect(result).toEqual(null)
+  scenario('removes a user', async (scenario: StandardScenario) => {
+    const original = await removeUser({ id: scenario.user.one.id })
+    const result = await user({
+      id: original.id,
+    })
+    expect(result.email).toEqual('removed@remove.com')
+    expect(result.name).toEqual('Removed User')
+    expect(result.nickname).toEqual(null)
+    expect(result.pronouns).toEqual(null)
+    expect(result.active).toEqual(false)
+    expect(result.admin).toEqual(false)
   })
 })

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -180,7 +180,7 @@ describe('users', () => {
     const result = await user({
       id: original.id,
     })
-    expect(result.email).toEqual('removed@remove.com')
+    expect(result.email).toEqual(result.id)
     expect(result.name).toEqual('Removed User')
     expect(result.nickname).toEqual(null)
     expect(result.pronouns).toEqual(null)

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -89,10 +89,19 @@ export const updateUser: MutationResolvers['updateUser'] = async ({
   return user
 }
 
-export const removeUser: MutationResolvers['removeUser'] = ({ id }) => {
-  return db.user.delete({
+export const removeUser: MutationResolvers['removeUser'] = async ({ id }) => {
+  const user = await db.user.update({
     where: { id },
+    data: {
+      email: 'removed@remove.com',
+      name: 'Removed User',
+      nickname: null,
+      pronouns: null,
+      active: false,
+      admin: false,
+    },
   })
+  return user
 }
 
 export const User: UserResolvers = {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -89,7 +89,7 @@ export const updateUser: MutationResolvers['updateUser'] = async ({
   return user
 }
 
-export const deleteUser: MutationResolvers['deleteUser'] = ({ id }) => {
+export const removeUser: MutationResolvers['removeUser'] = ({ id }) => {
   return db.user.delete({
     where: { id },
   })

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -93,7 +93,7 @@ export const removeUser: MutationResolvers['removeUser'] = async ({ id }) => {
   const user = await db.user.update({
     where: { id },
     data: {
-      email: 'removed@remove.com',
+      email: id,
       name: 'Removed User',
       nickname: null,
       pronouns: null,

--- a/web/src/components/Admin/User/User/User.tsx
+++ b/web/src/components/Admin/User/User/User.tsx
@@ -2,9 +2,9 @@ import { Link, routes, navigate } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-const DELETE_USER_MUTATION = gql`
-  mutation DeleteUserMutation($id: String!) {
-    deleteUser(id: $id) {
+const REMOVE_USER_MUTATION = gql`
+  mutation RemoveUserMutation($id: String!) {
+    removeUser(id: $id) {
       id
     }
   }
@@ -25,9 +25,9 @@ const checkboxInputTag = (checked) => {
 }
 
 const User = ({ user }) => {
-  const [deleteUser] = useMutation(DELETE_USER_MUTATION, {
+  const [removeUser] = useMutation(REMOVE_USER_MUTATION, {
     onCompleted: () => {
-      toast.success('User deleted')
+      toast.success('User removed')
       navigate(routes.adminUsers())
     },
     onError: (error) => {
@@ -35,9 +35,9 @@ const User = ({ user }) => {
     },
   })
 
-  const onDeleteClick = (id) => {
-    if (confirm('Are you sure you want to delete user ' + id + '?')) {
-      deleteUser({ variables: { id } })
+  const onRemoveClick = (id) => {
+    if (confirm('Are you sure you want to remove user ' + id + '?')) {
+      removeUser({ variables: { id } })
     }
   }
 
@@ -108,9 +108,9 @@ const User = ({ user }) => {
         <button
           type="button"
           className="rw-button rw-button-red"
-          onClick={() => onDeleteClick(user.id)}
+          onClick={() => onRemoveClick(user.id)}
         >
-          Delete
+          Remove
         </button>
       </nav>
     </>

--- a/web/src/components/Admin/User/User/User.tsx
+++ b/web/src/components/Admin/User/User/User.tsx
@@ -36,7 +36,13 @@ const User = ({ user }) => {
   })
 
   const onRemoveClick = (id) => {
-    if (confirm('Are you sure you want to remove user ' + id + '?')) {
+    if (
+      confirm(
+        'Removing the user will remove all their personal data. Are you sure you want to remove user ' +
+          id +
+          '?'
+      )
+    ) {
       removeUser({ variables: { id } })
     }
   }

--- a/web/src/components/Admin/User/Users/Users.tsx
+++ b/web/src/components/Admin/User/Users/Users.tsx
@@ -4,9 +4,9 @@ import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY } from 'src/components/Admin/User/UsersCell'
 
-const DELETE_USER_MUTATION = gql`
-  mutation DeleteUserMutation($id: String!) {
-    deleteUser(id: $id) {
+const REMOVE_USER_MUTATION = gql`
+  mutation RemoveUserMutation($id: String!) {
+    removeUser(id: $id) {
       id
     }
   }
@@ -43,9 +43,9 @@ const checkboxInputTag = (checked) => {
 }
 
 const UsersList = ({ users }) => {
-  const [deleteUser] = useMutation(DELETE_USER_MUTATION, {
+  const [removeUser] = useMutation(REMOVE_USER_MUTATION, {
     onCompleted: () => {
-      toast.success('User deleted')
+      toast.success('User removed')
     },
     onError: (error) => {
       toast.error(error.message)
@@ -67,9 +67,9 @@ const UsersList = ({ users }) => {
     awaitRefetchQueries: true,
   })
 
-  const onDeleteClick = (id) => {
-    if (confirm('Are you sure you want to delete user ' + id + '?')) {
-      deleteUser({ variables: { id } })
+  const onRemoveClick = (id) => {
+    if (confirm('Are you sure you want to remove user ' + id + '?')) {
+      removeUser({ variables: { id } })
     }
   }
   const onArchiveClick = (id, active) => {
@@ -130,11 +130,11 @@ const UsersList = ({ users }) => {
                   </Link>
                   <button
                     type="button"
-                    title={'Delete user ' + user.id}
+                    title={'Remove user ' + user.id}
                     className="rw-button rw-button-small rw-button-red"
-                    onClick={() => onDeleteClick(user.id)}
+                    onClick={() => onRemoveClick(user.id)}
                   >
-                    Delete
+                    Remove
                   </button>
 
                   <button

--- a/web/src/components/Admin/User/Users/Users.tsx
+++ b/web/src/components/Admin/User/Users/Users.tsx
@@ -4,13 +4,6 @@ import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY } from 'src/components/Admin/User/UsersCell'
 
-const REMOVE_USER_MUTATION = gql`
-  mutation RemoveUserMutation($id: String!) {
-    removeUser(id: $id) {
-      id
-    }
-  }
-`
 const ARCHIVE_USER_MUTATION = gql`
   mutation ArchiveUserMutation($id: String!, $input: UpdateUserInput!) {
     updateUser(id: $id, input: $input) {
@@ -43,19 +36,6 @@ const checkboxInputTag = (checked) => {
 }
 
 const UsersList = ({ users }) => {
-  const [removeUser] = useMutation(REMOVE_USER_MUTATION, {
-    onCompleted: () => {
-      toast.success('User removed')
-    },
-    onError: (error) => {
-      toast.error(error.message)
-    },
-    // This refetches the query on the list page. Read more about other ways to
-    // update the cache over here:
-    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: [{ query: QUERY }],
-    awaitRefetchQueries: true,
-  })
   const [archiveUser] = useMutation(ARCHIVE_USER_MUTATION, {
     onCompleted: () => {
       toast.success('User updated')
@@ -67,11 +47,6 @@ const UsersList = ({ users }) => {
     awaitRefetchQueries: true,
   })
 
-  const onRemoveClick = (id) => {
-    if (confirm('Are you sure you want to remove user ' + id + '?')) {
-      removeUser({ variables: { id } })
-    }
-  }
   const onArchiveClick = (id, active) => {
     if (confirm('Are you sure you want to archive user ' + id + '?')) {
       archiveUser({
@@ -128,14 +103,6 @@ const UsersList = ({ users }) => {
                   >
                     Edit
                   </Link>
-                  <button
-                    type="button"
-                    title={'Remove user ' + user.id}
-                    className="rw-button rw-button-small rw-button-red"
-                    onClick={() => onRemoveClick(user.id)}
-                  >
-                    Remove
-                  </button>
 
                   <button
                     type="button"


### PR DESCRIPTION
# Pull Request

## Story

Feature/34-admin-user-remove

## Description

Adds ability to remove a user but keep them in the database. 

## Solution

Delete User is now updated to Remove User. User is updated to stay in database, but replace all personal information to null. 

## Screenshots

<img width="1522" alt="Screen Shot 2022-09-01 at 12 35 15 PM" src="https://user-images.githubusercontent.com/101531284/187997793-640702e8-c08a-43f3-86b4-79e30c44e944.png">

<img width="977" alt="Screen Shot 2022-09-01 at 12 36 40 PM" src="https://user-images.githubusercontent.com/101531284/187997972-33839722-0be8-46e1-9b43-906545779a46.png">


## Affected Areas

User Admin, Users List, User Show, Users in GraphQl and Services

## Tests

Tests the User's personal information is removed, but user overall stays in database. 

## Was this feature tested on all browsers?

- [x] Chrome

## Definition of Done

- [ ] README updated
- [x] Tests written
- [ ] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

When a user is removed...
![mandatory](https://media.giphy.com/media/jUwpNzg9IcyrK/giphy.gif)
