### PR TITLE
🧹 Roles/Teams scenario rename

### DIFF
--- a/api/src/services/roles/roles.scenarios.ts
+++ b/api/src/services/roles/roles.scenarios.ts
@@ -25,12 +25,12 @@ export const associations = {
     }),
   },
   role: {
-    noUserRole: (): Prisma.RoleCreateArgs => ({
+    withoutUser: (): Prisma.RoleCreateArgs => ({
       data: {
         name: 'No-User-Role',
       },
     }),
-    userRole: (scenario): Prisma.RoleCreateArgs => ({
+    withUser: (scenario): Prisma.RoleCreateArgs => ({
       data: {
         name: 'User-Role',
         membershipRoles: {

--- a/api/src/services/roles/roles.scenarios.ts
+++ b/api/src/services/roles/roles.scenarios.ts
@@ -27,12 +27,12 @@ export const associations = {
   role: {
     noUserRole: (): Prisma.RoleCreateArgs => ({
       data: {
-        name: 'NOT-IN-USE',
+        name: 'No-User-Role',
       },
     }),
     userRole: (scenario): Prisma.RoleCreateArgs => ({
       data: {
-        name: 'IN-USE',
+        name: 'User-Role',
         membershipRoles: {
           create: {
             membership: {

--- a/api/src/services/roles/roles.scenarios.ts
+++ b/api/src/services/roles/roles.scenarios.ts
@@ -25,12 +25,12 @@ export const associations = {
     }),
   },
   role: {
-    notInUseRole: (): Prisma.RoleCreateArgs => ({
+    noUserRole: (): Prisma.RoleCreateArgs => ({
       data: {
         name: 'NOT-IN-USE',
       },
     }),
-    inUseRole: (scenario): Prisma.RoleCreateArgs => ({
+    userRole: (scenario): Prisma.RoleCreateArgs => ({
       data: {
         name: 'IN-USE',
         membershipRoles: {

--- a/api/src/services/roles/roles.scenarios.ts
+++ b/api/src/services/roles/roles.scenarios.ts
@@ -7,7 +7,7 @@ export const standard = defineScenario<Prisma.RoleCreateArgs>({
   },
 })
 
-export const inUse = {
+export const associations = {
   team: {
     team1: (): Prisma.TeamCreateArgs => ({
       data: {
@@ -49,6 +49,6 @@ export const inUse = {
 }
 
 export type StandardScenario = typeof standard
-export type InUseScenario = {
+export type AssociationsScenario = {
   role: Record<string, Prisma.RoleCreateArgs['data']>
 }

--- a/api/src/services/roles/roles.test.ts
+++ b/api/src/services/roles/roles.test.ts
@@ -41,7 +41,7 @@ describe('roles', () => {
   describe('deletes', () => {
     scenario(
       'associations',
-      'unused role',
+      'when no users',
       async (scenario: AssociationsScenario) => {
         const original = await deleteRole({ id: scenario.role.noUserRole.id })
         const result = await role({ id: original.id })
@@ -52,7 +52,7 @@ describe('roles', () => {
 
     scenario(
       'associations',
-      'role in use',
+      'when has users',
       async (scenario: AssociationsScenario) => {
         expect(deleteRole({ id: scenario.role.userRole.id })).rejects.toThrow(
           Error('Role is in use, please remove memberships before deletion')

--- a/api/src/services/roles/roles.test.ts
+++ b/api/src/services/roles/roles.test.ts
@@ -43,7 +43,7 @@ describe('roles', () => {
       'associations',
       'when no users',
       async (scenario: AssociationsScenario) => {
-        const original = await deleteRole({ id: scenario.role.noUserRole.id })
+        const original = await deleteRole({ id: scenario.role.withoutUser.id })
         const result = await role({ id: original.id })
 
         expect(result).toEqual(null)
@@ -54,12 +54,12 @@ describe('roles', () => {
       'associations',
       'when has users',
       async (scenario: AssociationsScenario) => {
-        expect(deleteRole({ id: scenario.role.userRole.id })).rejects.toThrow(
+        expect(deleteRole({ id: scenario.role.withUser.id })).rejects.toThrow(
           Error('Role is in use, please remove memberships before deletion')
         )
 
-        const result = await role({ id: scenario.role.userRole.id })
-        expect(result).toEqual(scenario.role.userRole)
+        const result = await role({ id: scenario.role.withUser.id })
+        expect(result).toEqual(scenario.role.withUser)
       }
     )
   })

--- a/api/src/services/roles/roles.test.ts
+++ b/api/src/services/roles/roles.test.ts
@@ -43,7 +43,7 @@ describe('roles', () => {
       'associations',
       'unused role',
       async (scenario: AssociationsScenario) => {
-        const original = await deleteRole({ id: scenario.role.notInUseRole.id })
+        const original = await deleteRole({ id: scenario.role.noUserRole.id })
         const result = await role({ id: original.id })
 
         expect(result).toEqual(null)
@@ -54,12 +54,12 @@ describe('roles', () => {
       'associations',
       'role in use',
       async (scenario: AssociationsScenario) => {
-        expect(deleteRole({ id: scenario.role.inUseRole.id })).rejects.toThrow(
+        expect(deleteRole({ id: scenario.role.userRole.id })).rejects.toThrow(
           Error('Role is in use, please remove memberships before deletion')
         )
 
-        const result = await role({ id: scenario.role.inUseRole.id })
-        expect(result).toEqual(scenario.role.inUseRole)
+        const result = await role({ id: scenario.role.userRole.id })
+        expect(result).toEqual(scenario.role.userRole)
       }
     )
   })

--- a/api/src/services/roles/roles.test.ts
+++ b/api/src/services/roles/roles.test.ts
@@ -1,5 +1,5 @@
 import { roles, role, createRole, updateRole, deleteRole } from './roles'
-import type { InUseScenario, StandardScenario } from './roles.scenarios'
+import type { AssociationsScenario, StandardScenario } from './roles.scenarios'
 
 describe('roles', () => {
   scenario('returns all roles', async (scenario: StandardScenario) => {
@@ -39,20 +39,28 @@ describe('roles', () => {
   })
 
   describe('deletes', () => {
-    scenario('inUse', 'unused role', async (scenario: InUseScenario) => {
-      const original = await deleteRole({ id: scenario.role.notInUseRole.id })
-      const result = await role({ id: original.id })
+    scenario(
+      'associations',
+      'unused role',
+      async (scenario: AssociationsScenario) => {
+        const original = await deleteRole({ id: scenario.role.notInUseRole.id })
+        const result = await role({ id: original.id })
 
-      expect(result).toEqual(null)
-    })
+        expect(result).toEqual(null)
+      }
+    )
 
-    scenario('inUse', 'role in use', async (scenario: InUseScenario) => {
-      expect(deleteRole({ id: scenario.role.inUseRole.id })).rejects.toThrow(
-        Error('Role is in use, please remove memberships before deletion')
-      )
+    scenario(
+      'associations',
+      'role in use',
+      async (scenario: AssociationsScenario) => {
+        expect(deleteRole({ id: scenario.role.inUseRole.id })).rejects.toThrow(
+          Error('Role is in use, please remove memberships before deletion')
+        )
 
-      const result = await role({ id: scenario.role.inUseRole.id })
-      expect(result).toEqual(scenario.role.inUseRole)
-    })
+        const result = await role({ id: scenario.role.inUseRole.id })
+        expect(result).toEqual(scenario.role.inUseRole)
+      }
+    )
   })
 })

--- a/api/src/services/teams/teams.scenarios.ts
+++ b/api/src/services/teams/teams.scenarios.ts
@@ -7,9 +7,9 @@ export const standard = defineScenario<Prisma.TeamCreateArgs>({
   },
 })
 
-export const inUse = {
+export const associations = {
   team: {
-    inUseTeam: (): Prisma.TeamCreateArgs => ({
+    team1: (): Prisma.TeamCreateArgs => ({
       data: {
         name: 'Team1',
       },
@@ -27,7 +27,7 @@ export const inUse = {
   membership: {
     membership1: (scenario): Prisma.MembershipCreateArgs => ({
       data: {
-        teamId: scenario.team.inUseTeam.id,
+        teamId: scenario.team.team1.id,
         userId: scenario.user.user1.id,
       },
     }),
@@ -35,6 +35,6 @@ export const inUse = {
 }
 
 export type StandardScenario = typeof standard
-export type InUseScenario = {
+export type AssociationsScenario = {
   team: Record<string, Prisma.TeamCreateArgs['data']>
 }

--- a/api/src/services/teams/teams.scenarios.ts
+++ b/api/src/services/teams/teams.scenarios.ts
@@ -9,7 +9,7 @@ export const standard = defineScenario<Prisma.TeamCreateArgs>({
 
 export const associations = {
   team: {
-    hasUser: (): Prisma.TeamCreateArgs => ({
+    withUser: (): Prisma.TeamCreateArgs => ({
       data: {
         name: 'User-Team',
       },
@@ -27,7 +27,7 @@ export const associations = {
   membership: {
     membership1: (scenario): Prisma.MembershipCreateArgs => ({
       data: {
-        teamId: scenario.team.hasUser.id,
+        teamId: scenario.team.withUser.id,
         userId: scenario.user.user1.id,
       },
     }),

--- a/api/src/services/teams/teams.scenarios.ts
+++ b/api/src/services/teams/teams.scenarios.ts
@@ -9,9 +9,9 @@ export const standard = defineScenario<Prisma.TeamCreateArgs>({
 
 export const associations = {
   team: {
-    team1: (): Prisma.TeamCreateArgs => ({
+    hasUser: (): Prisma.TeamCreateArgs => ({
       data: {
-        name: 'Team1',
+        name: 'User-Team',
       },
     }),
   },
@@ -27,7 +27,7 @@ export const associations = {
   membership: {
     membership1: (scenario): Prisma.MembershipCreateArgs => ({
       data: {
-        teamId: scenario.team.team1.id,
+        teamId: scenario.team.hasUser.id,
         userId: scenario.user.user1.id,
       },
     }),

--- a/api/src/services/teams/teams.test.ts
+++ b/api/src/services/teams/teams.test.ts
@@ -1,7 +1,7 @@
 import { ValidationError } from '@redwoodjs/graphql-server'
 
 import { teams, team, createTeam, updateTeam, deleteTeam } from './teams'
-import type { InUseScenario, StandardScenario } from './teams.scenarios'
+import type { AssociationsScenario, StandardScenario } from './teams.scenarios'
 
 describe('teams', () => {
   scenario('returns all teams', async (scenario: StandardScenario) => {
@@ -49,12 +49,12 @@ describe('teams', () => {
       expect(result).toEqual(null)
     })
 
-    scenario('inUse', 'used', async (scenario: InUseScenario) => {
-      expect(deleteTeam({ id: scenario.team.inUseTeam.id })).rejects.toThrow(
+    scenario('associations', 'used', async (scenario: AssociationsScenario) => {
+      expect(deleteTeam({ id: scenario.team.team1.id })).rejects.toThrow(
         new ValidationError('Please remove users before deleting team')
       )
 
-      const result = await team({ id: scenario.team.inUseTeam.id })
+      const result = await team({ id: scenario.team.team1.id })
 
       expect(result).not.toEqual(null)
     })

--- a/api/src/services/teams/teams.test.ts
+++ b/api/src/services/teams/teams.test.ts
@@ -53,11 +53,11 @@ describe('teams', () => {
       'associations',
       'when has users',
       async (scenario: AssociationsScenario) => {
-        expect(deleteTeam({ id: scenario.team.hasUser.id })).rejects.toThrow(
+        expect(deleteTeam({ id: scenario.team.withUser.id })).rejects.toThrow(
           new ValidationError('Please remove users before deleting team')
         )
 
-        const result = await team({ id: scenario.team.hasUser.id })
+        const result = await team({ id: scenario.team.withUser.id })
 
         expect(result).not.toEqual(null)
       }

--- a/api/src/services/teams/teams.test.ts
+++ b/api/src/services/teams/teams.test.ts
@@ -49,14 +49,18 @@ describe('teams', () => {
       expect(result).toEqual(null)
     })
 
-    scenario('associations', 'used', async (scenario: AssociationsScenario) => {
-      expect(deleteTeam({ id: scenario.team.team1.id })).rejects.toThrow(
-        new ValidationError('Please remove users before deleting team')
-      )
+    scenario(
+      'associations',
+      'when has users',
+      async (scenario: AssociationsScenario) => {
+        expect(deleteTeam({ id: scenario.team.hasUser.id })).rejects.toThrow(
+          new ValidationError('Please remove users before deleting team')
+        )
 
-      const result = await team({ id: scenario.team.team1.id })
+        const result = await team({ id: scenario.team.hasUser.id })
 
-      expect(result).not.toEqual(null)
-    })
+        expect(result).not.toEqual(null)
+      }
+    )
   })
 })

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -38,13 +38,13 @@ export const associations = {
     }),
   },
   user: {
-    teamUser: (): Prisma.UserCreateArgs => ({
+    withTeam: (): Prisma.UserCreateArgs => ({
       data: {
         email: 'teamUser@example.com',
         ...DEFAULT_FIELDS,
       },
     }),
-    noTeamUser: (): Prisma.UserCreateArgs => ({
+    withoutTeam: (): Prisma.UserCreateArgs => ({
       data: {
         email: 'noTeamUser@example.com',
         ...DEFAULT_FIELDS,
@@ -55,7 +55,7 @@ export const associations = {
     membership1: (scenario): Prisma.MembershipCreateArgs => ({
       data: {
         teamId: scenario.team.team1.id,
-        userId: scenario.user.teamUser.id,
+        userId: scenario.user.withTeam.id,
       },
     }),
   },

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -79,7 +79,7 @@ describe('users', () => {
       'associations',
       'when no teams',
       async (scenario: AssociationsScenario) => {
-        const original = await user({ id: scenario.user.noTeamUser.id })
+        const original = await user({ id: scenario.user.withoutTeam.id })
         const before = new Date()
         const result = await updateUser({
           id: original.id,
@@ -96,7 +96,7 @@ describe('users', () => {
       'associations',
       'when adding teams and roles',
       async (scenario: AssociationsScenario) => {
-        const id = scenario.user.noTeamUser.id
+        const id = scenario.user.withoutTeam.id
         const teamId = scenario.team.team1.id
         const teamIds = [scenario.team.team1.id]
         const roleId = scenario.role.role1.id
@@ -131,7 +131,7 @@ describe('users', () => {
       'associations',
       'when remove a team with roles',
       async (scenario: AssociationsScenario) => {
-        const original = await user({ id: scenario.user.teamUser.id })
+        const original = await user({ id: scenario.user.withTeam.id })
 
         const result = await updateUser({
           id: original.id,
@@ -154,7 +154,7 @@ describe('users', () => {
       'associations',
       'when user has teams but teams not passed',
       async (scenario: AssociationsScenario) => {
-        const original = await user({ id: scenario.user.teamUser.id })
+        const original = await user({ id: scenario.user.withTeam.id })
 
         const result = await updateUser({
           id: original.id,


### PR DESCRIPTION
# Pull Request

## Story

Resolves #52  Rename scenario data structure roles/teams services

## Solution

Naming data structure renamed in service roles and teams to match with users.  

## Affected Areas

Roles scenario, Roles tests, Teams scenario, Teams tests

## Tests

Tests are updated to reflect change in scenarios.

## Was this feature tested on all browsers?

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
- [ ] Safari

## Definition of Done

- [ ] README updated
- [X] Tests written
- [ ] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![mandatory](https://media.giphy.com/media/Xg9xtAwoxn3nEQEz4Y/giphy.gif)