### PR TITLE
Point package.json at prisma schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "yarn": ">=1.15"
   },
   "prisma": {
-    "seed": "yarn rw exec seed"
+    "seed": "yarn rw exec seed",
+    "schema": "api/db/schema.prisma"
   },
   "packageManager": "yarn@3.2.1",
   "scripts": {
@@ -46,7 +47,8 @@
     "db:seed": "yarn rw prisma db seed",
     "db:setup": "yarn db:migrate:dev && yarn db:seed && yarn db:migrate:data",
     "db:reset": "yarn rw prisma migrate reset",
-    "db:deploy": "yarn db:migrate:deploy && yarn db:migrate:data"
+    "db:deploy": "yarn db:migrate:deploy && yarn db:migrate:data",
+    "schema:format": "npx prisma format"
   },
   "dependencies": {
     "@redwoodjs/core": "^3.0.2",


### PR DESCRIPTION
# Pull Request


## Story

No Story

Fix #<ISSUE_ID>

## Description

This add a `prisma.schema` key to package.json which allows prisma commands to be run from the root directory without a `--schema` flag. For instance, if you have an issue while editing the schema file you can run `primsa format` and it can auto correct some issues.  I also aliased the command in the package.json scripts.

## Analysis and Design

Analyze and attach design documentation.

## Solution

Describe your code changes in detail for reviewers.

## Screenshots

Post the output screenshots, if an UI is affected or added due to this feature.

## Affected Areas

List out the areas affected by your code change.

## Tests

Describe the tests.

## Was this feature tested on all browsers?

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
- [ ] Safari

## Related PRs

Add any related pull requests

## Definition of Done

- [ ] README updated
- [ ] Tests written
- [ ] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![mandatory](https://media.giphy.com/media/3otPoUygHpFbzM350A/giphy.gif)
