### PR TITLE
✨ Feature #44 Allow admins to filter inactive users

### DIFF
--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -13,7 +13,7 @@ export const schema = gql`
   }
 
   type Query {
-    users: [User!]! @requireAuth(roles: ["super admin"])
+    users(active: Boolean): [User!]! @requireAuth(roles: ["super admin"])
     user(id: String!): User @requireAuth(roles: ["super admin"])
   }
 

--- a/api/src/lib/buildWhereClause/buildWhereClause.test.ts
+++ b/api/src/lib/buildWhereClause/buildWhereClause.test.ts
@@ -1,0 +1,32 @@
+import { buildWhereClause } from './buildWhereClause'
+
+describe('lib/buildWhereClause', () => {
+  describe('when no aruguments are present', () => {
+    it('returns undefined', () => {
+      expect(buildWhereClause()).toBeUndefined()
+      expect(buildWhereClause({})).toBeUndefined()
+    })
+  })
+
+  describe('when some arguments are undefined', () => {
+    it('returns undefined', () => {
+      expect(buildWhereClause({ active: undefined })).toBeUndefined()
+    })
+  })
+
+  describe('when arguments are present with values', () => {
+    it('returns the where clause', () => {
+      expect(buildWhereClause({ active: true })).toEqual({
+        where: { active: true },
+      })
+    })
+  })
+
+  describe('when some arguments have values and some are undefined', () => {
+    it('returns the where clause with only the arguments that have values', () => {
+      expect(buildWhereClause({ active: true, name: undefined })).toEqual({
+        where: { active: true },
+      })
+    })
+  })
+})

--- a/api/src/lib/buildWhereClause/buildWhereClause.ts
+++ b/api/src/lib/buildWhereClause/buildWhereClause.ts
@@ -1,0 +1,14 @@
+import { isEmpty, isNil, reject } from 'ramda'
+import { QueryuserArgs } from 'types/graphql'
+
+const removeUndefined = reject(isNil)
+
+export const buildWhereClause = (where?): { where: QueryuserArgs } => {
+  if (isNil(where)) return
+
+  const filteredWhere = removeUndefined(where)
+
+  if (isEmpty(filteredWhere)) return
+
+  return { where }
+}

--- a/api/src/lib/buildWhereClause/index.ts
+++ b/api/src/lib/buildWhereClause/index.ts
@@ -1,0 +1,1 @@
+export * from './buildWhereClause'

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -11,12 +11,14 @@ export const standard = defineScenario<Prisma.UserCreateArgs>({
       data: {
         email: 'String4589593',
         verifyToken: 'HarryPotter',
+        active: true,
         ...DEFAULT_FIELDS,
       },
     },
     two: {
       data: {
         email: 'String1300967',
+        active: false,
         ...DEFAULT_FIELDS,
       },
     },

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,11 +1,11 @@
 import { db } from 'src/lib/db'
 
 import {
-  users,
-  user,
   createUser,
-  updateUser,
   removeUser,
+  updateUser,
+  user,
+  users,
   verifyReset,
   verifyUser,
 } from './users'
@@ -24,6 +24,12 @@ describe('users', () => {
     const result = await users()
 
     expect(result.length).toEqual(Object.keys(scenario.user).length)
+  })
+
+  scenario('only returns active users', async () => {
+    const result = await users({ active: true })
+
+    expect(result.length).toEqual(1)
   })
 
   scenario('returns a single user', async (scenario: StandardScenario) => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -1,28 +1,15 @@
 import type { User as UserType } from '@prisma/client'
 import * as CryptoJS from 'crypto-js'
-import { isEmpty, isNil, reject } from 'ramda'
 import type {
   MutationResolvers,
   QueryResolvers,
-  QueryusersArgs,
   UserResolvers,
 } from 'types/graphql'
 
 import { email as verificationEmail } from 'src/emails/user-verification'
+import { buildWhereClause } from 'src/lib/buildWhereClause'
 import { db } from 'src/lib/db'
 import { sendEmail } from 'src/lib/mailer'
-
-const removeUndefined = reject(isNil)
-
-const buildWhereClause = (where): { where: QueryusersArgs } => {
-  if (isNil(where)) return
-
-  const filteredWhere = removeUndefined(where)
-
-  if (isEmpty(filteredWhere)) return
-
-  return { where }
-}
 
 const parseRoles = (roleIds) =>
   roleIds?.reduce((acc, id) => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -1,14 +1,28 @@
 import type { User as UserType } from '@prisma/client'
 import * as CryptoJS from 'crypto-js'
+import { isEmpty, isNil, reject } from 'ramda'
 import type {
-  QueryResolvers,
   MutationResolvers,
+  QueryResolvers,
+  QueryusersArgs,
   UserResolvers,
 } from 'types/graphql'
 
 import { email as verificationEmail } from 'src/emails/user-verification'
 import { db } from 'src/lib/db'
 import { sendEmail } from 'src/lib/mailer'
+
+const removeUndefined = reject(isNil)
+
+const buildWhereClause = (where): { where: QueryusersArgs } => {
+  if (isNil(where)) return
+
+  const filteredWhere = removeUndefined(where)
+
+  if (isEmpty(filteredWhere)) return
+
+  return { where }
+}
 
 const parseRoles = (roleIds) =>
   roleIds?.reduce((acc, id) => {
@@ -17,8 +31,8 @@ const parseRoles = (roleIds) =>
     return acc
   }, {})
 
-export const users: QueryResolvers['users'] = () => {
-  return db.user.findMany()
+export const users: QueryResolvers['users'] = (args: { active: boolean }) => {
+  return db.user.findMany(buildWhereClause(args))
 }
 
 export const user: QueryResolvers['user'] = ({ id }) => {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@redwoodjs/core": "^3.2.0",
-    "pm2": "^5.2.0"
+    "pm2": "^5.2.0",
+    "react-use": "^17.4.0"
   }
 }

--- a/web/src/components/Admin/User/UserCell/UserCell.tsx
+++ b/web/src/components/Admin/User/UserCell/UserCell.tsx
@@ -1,6 +1,6 @@
 import type { FindUserById } from 'types/graphql'
 
-import { CellSuccessProps, CellFailureProps, MetaTags } from '@redwoodjs/web'
+import { CellFailureProps, CellSuccessProps, MetaTags } from '@redwoodjs/web'
 
 import User from 'src/components/Admin/User/User'
 

--- a/web/src/components/Admin/User/Users/Users.tsx
+++ b/web/src/components/Admin/User/Users/Users.tsx
@@ -31,11 +31,11 @@ const timeTag = (datetime) => {
   )
 }
 
-const checkboxInputTag = (label, checked) => {
+const checkboxInputTag = (label, checked = true) => {
   return <input aria-label={label} type="checkbox" checked={checked} disabled />
 }
 
-const Users = ({ users }) => {
+const Users = ({ users, showInactive, toggleShowInactive }) => {
   const [archiveUser] = useMutation(ARCHIVE_USER_MUTATION, {
     onCompleted: () => {
       toast.success('User updated')
@@ -68,7 +68,17 @@ const Users = ({ users }) => {
             <th scope="col">Name</th>
             <th scope="col">Nickname</th>
             <th scope="col">Pronouns</th>
-            <th scope="col">Active</th>
+            <th scope="col">
+              Active
+              <p>
+                Show inactive:
+                <input
+                  type="checkbox"
+                  checked={showInactive}
+                  onChange={toggleShowInactive}
+                />
+              </p>
+            </th>
             <th scope="col">Admin</th>
             <th scope="col">Verified</th>
             <th scope="col">Updated at</th>

--- a/web/src/components/Admin/User/Users/Users.tsx
+++ b/web/src/components/Admin/User/Users/Users.tsx
@@ -31,11 +31,11 @@ const timeTag = (datetime) => {
   )
 }
 
-const checkboxInputTag = (label, checked = true) => {
+const checkboxInputTag = (label, checked) => {
   return <input aria-label={label} type="checkbox" checked={checked} disabled />
 }
 
-const Users = ({ users, showInactive, toggleShowInactive }) => {
+const Users = ({ users }) => {
   const [archiveUser] = useMutation(ARCHIVE_USER_MUTATION, {
     onCompleted: () => {
       toast.success('User updated')
@@ -63,27 +63,16 @@ const Users = ({ users, showInactive, toggleShowInactive }) => {
       <table className="rw-table">
         <thead>
           <tr>
-            <th scope="col">Id</th>
-            <th scope="col">Email</th>
-            <th scope="col">Name</th>
-            <th scope="col">Nickname</th>
-            <th scope="col">Pronouns</th>
-            <th scope="col">
-              Active
-              <p>
-                Show inactive:
-                <input
-                  type="checkbox"
-                  checked={showInactive}
-                  onChange={toggleShowInactive}
-                />
-              </p>
-            </th>
-            <th scope="col">Admin</th>
-            <th scope="col">Verified</th>
-            <th scope="col">Updated at</th>
-            <th scope="col">Created at</th>
-            <th scope="col">Actions</th>
+            <th>Id</th>
+            <th>Email</th>
+            <th>Name</th>
+            <th>Nickname</th>
+            <th>Pronouns</th>
+            <th>Active</th>
+            <th>Admin</th>
+            <th>Updated at</th>
+            <th>Created at</th>
+            <th>&nbsp;</th>
           </tr>
         </thead>
         <tbody>

--- a/web/src/components/Admin/User/UsersCell/UsersCell.tsx
+++ b/web/src/components/Admin/User/UsersCell/UsersCell.tsx
@@ -1,13 +1,22 @@
 import type { FindUsers } from 'types/graphql'
 
 import { Link, routes } from '@redwoodjs/router'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+import type { CellFailureProps, CellSuccessProps } from '@redwoodjs/web'
 
 import { Users } from '../Users'
 
+export const beforeQuery = ({
+  showInactive = false,
+}: {
+  showInactive: boolean
+}) => {
+  const active = showInactive ? undefined : true
+  return { variables: { active }, fetchPolicy: 'network-only' }
+}
+
 export const QUERY = gql`
-  query FindUsers {
-    users {
+  query FindUsers($active: Boolean) {
+    users(active: $active) {
       id
       email
       name

--- a/web/src/lib/hooks/index.js
+++ b/web/src/lib/hooks/index.js
@@ -1,0 +1,1 @@
+export * from './use-toggle'

--- a/web/src/lib/hooks/use-toggle.js
+++ b/web/src/lib/hooks/use-toggle.js
@@ -1,0 +1,1 @@
+export { useToggle } from 'react-use'

--- a/web/src/pages/Admin/User/UsersPage/UsersPage.tsx
+++ b/web/src/pages/Admin/User/UsersPage/UsersPage.tsx
@@ -1,12 +1,24 @@
 import { MetaTags } from '@redwoodjs/web'
 
 import UsersCell from 'src/components/Admin/User/UsersCell'
+import { useToggle } from 'src/lib/hooks'
 
 const UsersPage = () => {
+  const [showInactive, toggleShowInactive] = useToggle(false)
+
   return (
     <>
       <MetaTags title="Users" />
-      <UsersCell />
+      <div className="ml-4 mb-4 flex">
+        <div className="mr-2 text-sm font-light">Show inactive: </div>
+        <input
+          className="mt-0.5 cursor-pointer"
+          type="checkbox"
+          checked={showInactive}
+          onChange={toggleShowInactive}
+        />
+      </div>
+      <UsersCell showInactive={showInactive} />
     </>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,6 +1705,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.1.2":
+  version: 7.19.4
+  resolution: "@babel/runtime@npm:7.19.4"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 3ad7f298262cf1f060a3bf2be9f65afa3c034c9c7a2e7c9d3ec41ab58c944c86756d0e0fdfc08d178f983f48d6b5613c15253d83216fbe02b6141c13d28f12e5
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.12.7, @babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3":
   version: 7.18.10
   resolution: "@babel/template@npm:7.18.10"
@@ -5871,6 +5880,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/js-cookie@npm:^2.2.6":
+  version: 2.2.7
+  resolution: "@types/js-cookie@npm:2.2.7"
+  checksum: 29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
+  languageName: node
+  linkType: hard
+
 "@types/js-levenshtein@npm:^1.1.1":
   version: 1.1.1
   resolution: "@types/js-levenshtein@npm:1.1.1"
@@ -6822,6 +6838,13 @@ __metadata:
   version: 0.7.5
   resolution: "@xmldom/xmldom@npm:0.7.5"
   checksum: 768a1ca941bba8734f0c2d4ede971cc95a534cee0736d8ec472e38caa6c3a94c9693fa0aca27dc401ad554342cdf332c1717ceb11941533ec2d3b97aa07bfd9f
+  languageName: node
+  linkType: hard
+
+"@xobotyi/scrollbar-width@npm:^1.9.5":
+  version: 1.9.5
+  resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
+  checksum: 4ebc79e4f798e2a5e89a5122f8fc4a086f08a92a44ac020599c4fe20d105b7d76ba06c094260b5f386a75e7ce6f6c518d9fc295228b651296b99c4477f986ac4
   languageName: node
   linkType: hard
 
@@ -9697,6 +9720,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"copy-to-clipboard@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "copy-to-clipboard@npm:3.3.2"
+  dependencies:
+    toggle-selection: ^1.0.6
+  checksum: 295b987e47d3e89a421db4a6060276167bee0f14245e0e447613c060a9af806610a2958a0b9bc4512c7329a1d38fb4baf903979b443c63b03d2bc9968ce66ab6
+  languageName: node
+  linkType: hard
+
 "copy-webpack-plugin@npm:11.0.0":
   version: 11.0.0
   resolution: "copy-webpack-plugin@npm:11.0.0"
@@ -10005,6 +10037,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-in-js-utils@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "css-in-js-utils@npm:2.0.1"
+  dependencies:
+    hyphenate-style-name: ^1.0.2
+    isobject: ^3.0.1
+  checksum: 6696cda3ebd596fc42ff40059546786936a8cf709e00bc8dedce6cd42c2b3edb19333a5d5bba6ac35b75b58cf55c021cee7ab3ec0f13fb2cf59fbb024ba0894f
+  languageName: node
+  linkType: hard
+
 "css-loader@npm:6.7.1":
   version: 6.7.1
   resolution: "css-loader@npm:6.7.1"
@@ -10259,6 +10301,13 @@ __metadata:
   version: 3.1.0
   resolution: "csstype@npm:3.1.0"
   checksum: 4edcf1eb8b8e83e8b1dc557d9f61e720012e6d2453f4c05fa4221dacf604c4d7552383f0cead9adea4b3f23e3da3aa25cc4fb05823b51fb1cbad43e1d8bb45ff
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.0.6":
+  version: 3.1.1
+  resolution: "csstype@npm:3.1.1"
+  checksum: 7c8b8c5923049d84132581c13bae6e1faf999746fe3998ba5f3819a8e1cdc7512ace87b7d0a4a69f0f4b8ba11daf835d4f1390af23e09fc4f0baad52c084753a
   languageName: node
   linkType: hard
 
@@ -12313,6 +12362,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-shallow-equal@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-shallow-equal@npm:1.0.0"
+  checksum: 526c393c011ab5a0ca5a36c5ea25c9730acd027503ccbec6c7825397ab9375f51f67f14c8829b4c4b1ccccede695391dd14863a15e40a37fc4af08c1440a1b66
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^2.0.0, fast-uri@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-uri@npm:2.1.0"
@@ -12331,6 +12387,13 @@ __metadata:
   version: 1.0.16
   resolution: "fastest-levenshtein@npm:1.0.16"
   checksum: 7e3d8ae812a7f4fdf8cad18e9cde436a39addf266a5986f653ea0d81e0de0900f50c0f27c6d5aff3f686bcb48acbd45be115ae2216f36a6a13a7dbbf5cad878b
+  languageName: node
+  linkType: hard
+
+"fastest-stable-stringify@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "fastest-stable-stringify@npm:2.0.2"
+  checksum: abbe5ff48f13f5819e7312dbb38bae5d9960694cffd315b464df9adcd02a8fa7e9eec32c314655674c7134905c544b7a0c14b05bfbe30b3f678609bebc9fecb9
   languageName: node
   linkType: hard
 
@@ -14106,6 +14169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hyphenate-style-name@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "hyphenate-style-name@npm:1.0.4"
+  checksum: b19c3e2cd1dc426f6f893752fec08140abf79058a1b6238422e45373ed81389f02e1a2ba2ef4e9b2430d4e900a0f5ba12307de82320604e81ac1b722abd2ee62
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24, iconv-lite@npm:^0.4.4":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -14292,6 +14362,15 @@ __metadata:
   version: 0.1.1
   resolution: "inline-style-parser@npm:0.1.1"
   checksum: 08832a533f51a1e17619f2eabf2f5ec5e956d6dcba1896351285c65df022c9420de61d73256e1dca8015a52abf96cc84ddc3b73b898b22de6589d3962b5e501b
+  languageName: node
+  linkType: hard
+
+"inline-style-prefixer@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "inline-style-prefixer@npm:6.0.1"
+  dependencies:
+    css-in-js-utils: ^2.0.0
+  checksum: 02d2e0d9971a20c35ee1deba1b6a8677e1a105cdf6a17b36356c438bf1a064c99cba1e7cc97d0999c388a93b36ec08977cd0258d4e4b7be9d42cf096bba75831
   languageName: node
   linkType: hard
 
@@ -15705,6 +15784,13 @@ __metadata:
   dependencies:
     "@panva/asn1.js": ^1.0.0
   checksum: f6d1090ead9ddbf04b9717abcae6eb3d8d35f51c5c069e87780873e177b309ec594f4aa0ec7fdf456502bfee8d57c7dae1d24a531d7be2bbfd37eb1d402ffdf1
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "js-cookie@npm:2.2.1"
+  checksum: ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
   languageName: node
   linkType: hard
 
@@ -17417,6 +17503,25 @@ __metadata:
   dependencies:
     node-gyp: latest
   checksum: 95204e4ed2970c0411735d866b0a71f30625e9ce598d2f7c2dfc2145dcd4e8e48dda26fda2587657f91e96973044353d300a9a6d259079b342fa4b30548aa8fa
+  languageName: node
+  linkType: hard
+
+"nano-css@npm:^5.3.1":
+  version: 5.3.5
+  resolution: "nano-css@npm:5.3.5"
+  dependencies:
+    css-tree: ^1.1.2
+    csstype: ^3.0.6
+    fastest-stable-stringify: ^2.0.2
+    inline-style-prefixer: ^6.0.0
+    rtl-css-js: ^1.14.0
+    sourcemap-codec: ^1.4.8
+    stacktrace-js: ^2.0.2
+    stylis: ^4.0.6
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 6f9f3b0cd68758514ac2a61ad7d846c2ba57da49a076cbaf2a4871f4c5f0f1f1bbd87ea557de4440a8ee67f1dc6314e3f0ed26805984f2f2eb819856f87a8c7c
   languageName: node
   linkType: hard
 
@@ -20211,6 +20316,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-universal-interface@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "react-universal-interface@npm:0.6.2"
+  peerDependencies:
+    react: "*"
+    tslib: "*"
+  checksum: 97c32ecb7a425c3bcaa92dcf84c46146b49610d928efde9e9ee5518c475a0db942f01634dd490e4f42fcd95cc2f49657c1b96dcef96423c06f077147fe1968ab
+  languageName: node
+  linkType: hard
+
+"react-use@npm:^17.4.0":
+  version: 17.4.0
+  resolution: "react-use@npm:17.4.0"
+  dependencies:
+    "@types/js-cookie": ^2.2.6
+    "@xobotyi/scrollbar-width": ^1.9.5
+    copy-to-clipboard: ^3.3.1
+    fast-deep-equal: ^3.1.3
+    fast-shallow-equal: ^1.0.0
+    js-cookie: ^2.2.1
+    nano-css: ^5.3.1
+    react-universal-interface: ^0.6.2
+    resize-observer-polyfill: ^1.5.1
+    screenfull: ^5.1.0
+    set-harmonic-interval: ^1.0.1
+    throttle-debounce: ^3.0.1
+    ts-easing: ^0.2.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+  checksum: 9f9a56a5dbeb707186d470882a17d22e4d0845e7d77b576f4f23f07e7bc60600c7ca14bef33d62d0607f0a7ce18b465807cc9a120bdb75486985afc57d45da19
+  languageName: node
+  linkType: hard
+
 "react@npm:17.0.2":
   version: 17.0.2
   resolution: "react@npm:17.0.2"
@@ -20733,6 +20873,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resize-observer-polyfill@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 5e882475067f0b97dc07e0f37c3e335ac5bc3520d463f777cec7e894bb273eddbfecb857ae668e6fb6881fd6f6bb7148246967172139302da50fa12ea3a15d95
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -20932,6 +21079,7 @@ __metadata:
     "@redwoodjs/core": ^3.2.0
     pm2: ^5.2.0
     prettier: ^2.7.1
+    react-use: ^17.4.0
   languageName: unknown
   linkType: soft
 
@@ -20939,6 +21087,15 @@ __metadata:
   version: 4.8.5
   resolution: "rsvp@npm:4.8.5"
   checksum: 7978f01060a48204506a8ebe15cdbd468498f5ae538b1d7ee3e7630375ba7cb2f98df2f596c12d3f4d5d5c21badc1c6ca8009f5142baded8511609a28eabd19a
+  languageName: node
+  linkType: hard
+
+"rtl-css-js@npm:^1.14.0":
+  version: 1.16.0
+  resolution: "rtl-css-js@npm:1.16.0"
+  dependencies:
+    "@babel/runtime": ^7.1.2
+  checksum: 67cbec9e3493f3b6caf98abbd1d5d6c7a40ebcefd822bf833eb91e360e21a60622d575c517089909420f0cce5474d6c5c8c249bbbe21f187ae04a287ef29b683
   languageName: node
   linkType: hard
 
@@ -21141,6 +21298,13 @@ __metadata:
     ajv-formats: ^2.1.1
     ajv-keywords: ^5.0.0
   checksum: d76f1b0724fb74fa9da19d4f98ebe89c2703d8d28df9dc44d66ab9a9cbca869b434181a36a2bc00ec53980f27e8fabe143759bdc8754692bbf7ef614fc6e9da4
+  languageName: node
+  linkType: hard
+
+"screenfull@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "screenfull@npm:5.2.0"
+  checksum: 86fd49983e2edc153ee2e674a570c711cb0961a9cacca659309f79636ccc8ca8a0b830ea4dacdae7403a8bb7ba6affd5bcdce053aa97782961247a49bfd2ba68
   languageName: node
   linkType: hard
 
@@ -21347,6 +21511,13 @@ __metadata:
   version: 2.5.1
   resolution: "set-cookie-parser@npm:2.5.1"
   checksum: 7a22e3ef0f5f762eb8c0e71426bcf7050b481ac483bbb3a2175a2a233d40e473fdc9d0f460e63e3c63b7e0da00d696d8e067eb62fd1cd0a73e015b9cae444d61
+  languageName: node
+  linkType: hard
+
+"set-harmonic-interval@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "set-harmonic-interval@npm:1.0.1"
+  checksum: 49014d928a62c8418507bf66ffef7066783e8fb19f76e955318bbae5a8c4b56e1a7176b370f9040ef9de51531aa522a3f96fa5c47b1534635aa577ff7c12f9c6
   languageName: node
   linkType: hard
 
@@ -21728,6 +21899,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: beb2c5974bb58954d75e86249953d47ae16f7df1a8531abb9fcae0cd262d9fa09c2db3a134e20e99358b1adba42b6b054a32c8e16b571b3efcf6af644c329f0d
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.5.0, source-map@npm:^0.5.6":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
@@ -21746,6 +21924,13 @@ __metadata:
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
   checksum: dc0cf3768fe23c345ea8760487f8c97ef6fca8a73c83cd7c9bf2fde8bc2c34adb9c0824d6feb14bc4f9e37fb522e18af621543f1289038a66ac7586da29aa7dc
+  languageName: node
+  linkType: hard
+
+"sourcemap-codec@npm:^1.4.8":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: f099279fdaae070ff156df7414bbe39aad69cdd615454947ed3e19136bfdfcb4544952685ee73f56e17038f4578091e12b17b283ed8ac013882916594d95b9e6
   languageName: node
   linkType: hard
 
@@ -21897,6 +22082,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-generator@npm:^2.0.5":
+  version: 2.0.10
+  resolution: "stack-generator@npm:2.0.10"
+  dependencies:
+    stackframe: ^1.3.4
+  checksum: c3f6f6c580488e65c0fee806a57f6ae4b79e6435f144be471c1f20328a8d9d8492d4f3beed31840f6dae03e2633325e2764fd3aca5c3126a0639e7c9ddfa45ce
+  languageName: node
+  linkType: hard
+
 "stack-utils@npm:^2.0.3":
   version: 2.0.5
   resolution: "stack-utils@npm:2.0.5"
@@ -21910,6 +22104,27 @@ __metadata:
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
   checksum: 18410f7a1e0c5d211a4effa83bdbf24adbe8faa8c34db52e1cd3e89837518c592be60b60d8b7270ac53eeeb8b807cd11b399a41667f6c9abb41059c3ccc8a989
+  languageName: node
+  linkType: hard
+
+"stacktrace-gps@npm:^3.0.4":
+  version: 3.1.2
+  resolution: "stacktrace-gps@npm:3.1.2"
+  dependencies:
+    source-map: 0.5.6
+    stackframe: ^1.3.4
+  checksum: 0dcc1aa46e364a2b4d1eabce4777fecf337576a11ee3cfc92f07b9ec79ccb76810752431eeb9771289d250d0bb58dbe19a178b96bf7b2e9f773334d03aa96bb9
+  languageName: node
+  linkType: hard
+
+"stacktrace-js@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "stacktrace-js@npm:2.0.2"
+  dependencies:
+    error-stack-parser: ^2.0.6
+    stack-generator: ^2.0.5
+    stacktrace-gps: ^3.0.4
+  checksum: 9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
   languageName: node
   linkType: hard
 
@@ -22289,6 +22504,13 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 2c46413f9c21617f2537522ee89bd88416cf0dd1d4a7998da4445666cbd01364ec371ae326c2978df36ea020d1f161aa478feb70c7bb32e8085b0857e552c603
+  languageName: node
+  linkType: hard
+
+"stylis@npm:^4.0.6":
+  version: 4.1.2
+  resolution: "stylis@npm:4.1.2"
+  checksum: 09800a138711a501d9266a9877c435f948cd9e68f7369761949e1c2982161b5adbf9e8045cc2b0c47ca7f297fc166362da4a75ef54fe6c3aa024df2b1507a3a1
   languageName: node
   linkType: hard
 
@@ -22831,6 +23053,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"toggle-selection@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "toggle-selection@npm:1.0.6"
+  checksum: f2cf1f2c70f374fd87b0cdc8007453ba9e981c4305a8bf4eac10a30e62ecdfd28bca7d18f8f15b15a506bf8a7bfb20dbe3539f0fcf2a2c8396c1a78d53e1f179
+  languageName: node
+  linkType: hard
+
 "toidentifier@npm:1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
@@ -22938,6 +23167,13 @@ __metadata:
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 175adea838468cc2ff7d5e97f970dcb798bbcb623f29c6088cb21aa2880d207c5784be81ab1741f56b9ac37840cbaba0c0d79f7f8b67ffe61c02634cafa5c303
+  languageName: node
+  linkType: hard
+
+"ts-easing@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "ts-easing@npm:0.2.0"
+  checksum: 84ec20192310c697ff890ca2e0625e131a32596a7c5956326c9632faca9037abf2dd3de4d81ac358ae9f26a6a2cfe2300f13756b26995f753d882e3d0463e327
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Pull Request

Remove all sections below that are not needed

## Story

Resolves #44 

## Description

In the admin users page, the list filters out inactive users by default. There is a checkbox that allows them to show inactive users.

## Analysis and Design



## Solution

- Update users service to take an `active` argument and scope users accordingly
- Update UsersCell to only show active by default
- Add checkbox to UsersPage to allow toggling to show inactive

## Screenshots

![Screen Shot 2022-10-07 at 3 20 13 PM](https://user-images.githubusercontent.com/7717198/194900517-26489bde-f852-45d4-bb8f-07ec3d7d84fb.png)

## Affected Areas

List out the areas affected by your code change.

## Tests

Describe the tests.

## Was this feature tested on all browsers?

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
- [ ] Safari

## Related PRs

Add any related pull requests

## Definition of Done

- [ ] README updated
- [x] Tests written
- [x] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![mandatory](https://media.giphy.com/media/3otPoUygHpFbzM350A/giphy.gif)
