### PR TITLE
✨ Feature/50 Forgot Password Recovery Email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=password
 USERS_PASSWORD=password
 
+DOMAIN=
 SMTP_HOST=
 SMTP_PORT=
 SMTP_USER=

--- a/api/src/emails/forgot-password.ts
+++ b/api/src/emails/forgot-password.ts
@@ -1,0 +1,27 @@
+import type { User } from '@prisma/client'
+
+import { logger } from 'src/lib/logger'
+
+const recovery = {
+  subject: () => 'Forgot Password',
+  text: (user: User) => {
+    const link = `${process.env.DOMAIN}/reset-password?resetToken=${user.resetToken}`
+    const appName = process.env.APP_NAME
+
+    logger.debug(link)
+
+    return `
+        <div> Hi ${userNameWithFallback(user)}, </div>
+        <p>Please find below a link to reset your password for the ${appName}:</p>
+        <a href="${link}">${link}</a>
+        <p>If you did not request an account, please ignore this email.</p>
+      `
+  },
+}
+
+// TODO: extract to utils that can be shared with api and web
+const userNameWithFallback = (user: User) => {
+  return user.name || user.nickname || user.email
+}
+
+export { recovery }

--- a/api/src/emails/forgot-password.ts
+++ b/api/src/emails/forgot-password.ts
@@ -1,8 +1,9 @@
 import type { User } from '@prisma/client'
 
 import { logger } from 'src/lib/logger'
+import { userNameWithFallback } from 'src/lib/username'
 
-const recovery = {
+const email = {
   subject: () => 'Forgot Password',
   text: (user: User) => {
     const link = `${process.env.DOMAIN}/reset-password?resetToken=${user.resetToken}`
@@ -12,16 +13,11 @@ const recovery = {
 
     return `
         <div> Hi ${userNameWithFallback(user)}, </div>
-        <p>Please find below a link to reset your password for the ${appName}:</p>
+        <p>Please find below a link to reset your password for ${appName}:</p>
         <a href="${link}">${link}</a>
-        <p>If you did not request an account, please ignore this email.</p>
+        <p>If you did not request to reset your password, please ignore this email.</p>
       `
   },
 }
 
-// TODO: extract to utils that can be shared with api and web
-const userNameWithFallback = (user: User) => {
-  return user.name || user.nickname || user.email
-}
-
-export { recovery }
+export { email }

--- a/api/src/emails/user-verification.ts
+++ b/api/src/emails/user-verification.ts
@@ -1,6 +1,7 @@
 import type { User } from '@prisma/client'
 
 import { logger } from 'src/lib/logger'
+import { userNameWithFallback } from 'src/lib/username'
 
 const email = {
   subject: () => 'Verify Email',
@@ -19,11 +20,6 @@ const email = {
         <p>If you did not request an account, please ignore this email.</p>
       `
   },
-}
-
-// TODO: extract to utils that can be shared with api and web
-const userNameWithFallback = (user: User) => {
-  return user.name || user.nickname || user.email
 }
 
 export { email }

--- a/api/src/functions/auth.ts
+++ b/api/src/functions/auth.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 
 import { DbAuthHandler } from '@redwoodjs/api'
 
+import { recovery } from 'src/emails/forgot-password'
 import { email as verificationEmail } from 'src/emails/user-verification'
 import { db } from 'src/lib/db'
 import { sendEmail } from 'src/lib/mailer'
@@ -21,12 +22,13 @@ export const handler = async (event, context) => {
     // address in a toast message so the user will know it worked and where
     // to look for the email.
     handler: (user) => {
-      if (!user.active) {
-        throw new Error('User not Active')
-      }
+      sendEmail({
+        to: user.email,
+        subject: recovery.subject(),
+        text: recovery.text(user),
+      })
       return user
     },
-
     // How long the resetToken is valid for, in seconds (default is 24 hours)
     expires: 60 * 60 * 24,
 

--- a/api/src/functions/auth.ts
+++ b/api/src/functions/auth.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 
 import { DbAuthHandler } from '@redwoodjs/api'
 
-import { recovery } from 'src/emails/forgot-password'
+import { email as forgotPasswordEmail } from 'src/emails/forgot-password'
 import { email as verificationEmail } from 'src/emails/user-verification'
 import { db } from 'src/lib/db'
 import { sendEmail } from 'src/lib/mailer'
@@ -24,8 +24,8 @@ export const handler = async (event, context) => {
     handler: (user) => {
       sendEmail({
         to: user.email,
-        subject: recovery.subject(),
-        text: recovery.text(user),
+        subject: forgotPasswordEmail.subject(),
+        text: forgotPasswordEmail.text(user),
       })
       return user
     },

--- a/api/src/lib/username.ts
+++ b/api/src/lib/username.ts
@@ -1,0 +1,5 @@
+import type { User } from '@prisma/client'
+
+export const userNameWithFallback = (user: User) => {
+  return user.name || user.nickname || user.email
+}

--- a/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
+++ b/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
@@ -1,0 +1,7 @@
+import ForgotPasswordPage from './ForgotPasswordPage'
+
+export const generated = (args) => {
+  return <ForgotPasswordPage {...args} />
+}
+
+export default { title: 'Pages/ForgotPasswordPage' }

--- a/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -15,13 +15,13 @@ const ForgotPasswordPage = () => {
     }
   }, [isAuthenticated])
 
-  const usernameRef = useRef<HTMLInputElement>()
+  const emailRef = useRef<HTMLInputElement>()
   useEffect(() => {
-    usernameRef.current.focus()
+    emailRef.current.focus()
   }, [])
 
   const onSubmit = async (data) => {
-    const response = await forgotPassword(data.username)
+    const response = await forgotPassword(data.email)
 
     if (response.error) {
       toast.error(response.error)
@@ -55,23 +55,23 @@ const ForgotPasswordPage = () => {
                 <Form onSubmit={onSubmit} className="rw-form-wrapper">
                   <div className="text-left">
                     <Label
-                      name="username"
+                      name="email"
                       className="rw-label"
                       errorClassName="rw-label rw-label-error"
                     >
-                      Username
+                      Email
                     </Label>
                     <TextField
-                      name="username"
+                      name="email"
                       className="rw-input"
                       errorClassName="rw-input rw-input-error"
-                      ref={usernameRef}
+                      ref={emailRef}
                       validation={{
                         required: true,
                       }}
                     />
 
-                    <FieldError name="username" className="rw-field-error" />
+                    <FieldError name="email" className="rw-field-error" />
                   </div>
 
                   <div className="rw-button-group">

--- a/web/src/pages/ResetPasswordPage/ResetPasswordPage.stories.tsx
+++ b/web/src/pages/ResetPasswordPage/ResetPasswordPage.stories.tsx
@@ -1,0 +1,7 @@
+import ResetPasswordPage from './ResetPasswordPage'
+
+export const generated = (args) => {
+  return <ResetPasswordPage {...args} />
+}
+
+export default { title: 'Pages/ResetPasswordPage' }


### PR DESCRIPTION
## Story

Fix #50 

## Description

-Forgot password sends the user an email to reset password 
-Email should contain reset token and direct to reset password page

## Solution

-Update Auth for forgot password handler. 
-Add email setup for user to reset password through link with reset token 

## Screenshots

![Screenshot 2022-10-26 at 9 19 57 AM](https://user-images.githubusercontent.com/101531284/198080502-b90f6084-c084-41c2-b434-673a64c09793.png)

## Affected Areas

Functions/Auth, Emails, Forgot Password page, env example

## Was this feature tested on all browsers?

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
- [ ] Safari

## Definition of Done

- [ ] README updated
- [ ] Tests written
- [ ] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![mandatory](https://media.giphy.com/media/3oriO0Zip6jqAZEE1i/giphy.gif)
