### PR TITLE
🐛 Bug/110 clear session cache after logout

### DIFF
--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@redwoodjs/auth'
-import { navigate, NavLink, routes } from '@redwoodjs/router'
+import { NavLink, routes } from '@redwoodjs/router'
 
 const LinkItem = (props) => (
   <li data-testid="nav__link-item" className="mr-3 cursor-pointer">
@@ -11,13 +11,6 @@ const LinkItem = (props) => (
 const Navigation = () => {
   const { currentUser, hasRole, isAuthenticated, logOut } = useAuth()
 
-  const handleLogOut = async () => {
-    await logOut()
-
-    navigate(routes.home())
-    location.reload()
-  }
-
   return (
     <div>
       <div data-testid="nav" className="my-3 flex">
@@ -25,7 +18,7 @@ const Navigation = () => {
           <LinkItem to={routes.home()}>Home</LinkItem>
           {isAuthenticated ? (
             <li data-testid="nav__link-item" className="mr-3 cursor-pointer">
-              <button onClick={handleLogOut}>Logout</button>
+              <button onClick={logOut}>Logout</button>
             </li>
           ) : (
             <LinkItem to={routes.login()}>Login</LinkItem>

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@redwoodjs/auth'
-import { NavLink, navigate, routes } from '@redwoodjs/router'
+import { navigate, NavLink, routes } from '@redwoodjs/router'
 
 const LinkItem = (props) => (
   <li data-testid="nav__link-item" className="mr-3 cursor-pointer">
@@ -11,9 +11,11 @@ const LinkItem = (props) => (
 const Navigation = () => {
   const { currentUser, hasRole, isAuthenticated, logOut } = useAuth()
 
-  const handleLogOut = () => {
-    navigate('/')
-    logOut() && window.location.reload()
+  const handleLogOut = async () => {
+    await logOut()
+
+    navigate(routes.home())
+    location.reload()
   }
 
   return (

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@redwoodjs/auth'
-import { NavLink, routes } from '@redwoodjs/router'
+import { NavLink, navigate, routes } from '@redwoodjs/router'
 
 const LinkItem = (props) => (
   <li data-testid="nav__link-item" className="mr-3 cursor-pointer">
@@ -11,6 +11,11 @@ const LinkItem = (props) => (
 const Navigation = () => {
   const { currentUser, hasRole, isAuthenticated, logOut } = useAuth()
 
+  const handleLogOut = () => {
+    navigate('/')
+    logOut() && window.location.reload()
+  }
+
   return (
     <div>
       <div data-testid="nav" className="my-3 flex">
@@ -18,7 +23,7 @@ const Navigation = () => {
           <LinkItem to={routes.home()}>Home</LinkItem>
           {isAuthenticated ? (
             <li data-testid="nav__link-item" className="mr-3 cursor-pointer">
-              <button onClick={logOut}>Logout</button>
+              <button onClick={handleLogOut}>Logout</button>
             </li>
           ) : (
             <LinkItem to={routes.login()}>Login</LinkItem>

--- a/web/src/components/Profile/EditProfileCell/EditProfileCell.tsx
+++ b/web/src/components/Profile/EditProfileCell/EditProfileCell.tsx
@@ -6,6 +6,13 @@ import { toast } from '@redwoodjs/web/toast'
 
 import { EditProfile } from '../EditProfile'
 
+export const beforeQuery = (props) => {
+  return {
+    variables: props,
+    fetchPolicy: 'no-cache',
+  }
+}
+
 export const QUERY = gql`
   query Profile {
     profile {


### PR DESCRIPTION
# Pull Request

## Story

Fix #110 

## Description

Clear the cache for the profile form to pre-fill with the current user's information

## Analysis and Design

Form is prefilled with current user 

## Solution

Add a beforeQuery in the EditProfileCell to clear the cache before a query was made to the api side. 

## Affected Areas

EditProfileCell

## Was this feature tested on all browsers?

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
- [ ] Safari

## Definition of Done

- [ ] README updated
- [ ] Tests written
- [ ] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![mandatory](https://media.giphy.com/media/26FPqAHtgCBzKG9mo/giphy.gif)
