### PR TITLE
✨ Navigation Add Sign Up

### DIFF
--- a/web/src/components/Navigation/Navigation.test.tsx
+++ b/web/src/components/Navigation/Navigation.test.tsx
@@ -25,9 +25,17 @@ describe('Navigation', () => {
     renderComponent()
     const element = screen.getByText('Login')
 
-    expect(screen.getAllByTestId('nav__link-item').length).toBe(2)
+    expect(screen.getAllByTestId('nav__link-item').length).toBe(3)
     expect(element).toBeVisible()
     expect(element).toHaveAttribute('href', routes.login())
+  })
+
+  it('shows the sign up when not authenticated', () => {
+    renderComponent()
+    const element = screen.getByText('Sign Up')
+
+    expect(element).toBeVisible()
+    expect(element).toHaveAttribute('href', routes.signup())
   })
 
   it('shows logout when authenticated', async () => {

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -21,7 +21,10 @@ const Navigation = () => {
               <button onClick={logOut}>Logout</button>
             </li>
           ) : (
-            <LinkItem to={routes.login()}>Login</LinkItem>
+            <li className="flex">
+              <LinkItem to={routes.login()}>Login</LinkItem>
+              <LinkItem to={routes.signup()}>Sign Up</LinkItem>
+            </li>
           )}
           {hasRole('super admin') && (
             <LinkItem to={routes.adminUsers()}>Admin</LinkItem>


### PR DESCRIPTION
## Story

Fix #133 

## Description

Sign Up navigation visible when not signed in. 

## Solution

Add LinkItem in Navigation for SignUp

## Screenshots

![Screenshot 2022-11-17 at 8 42 21 AM](https://user-images.githubusercontent.com/101531284/202505527-b3959a36-0910-4fe6-9204-fe4ed8596fe5.png)

## Affected Areas

Navigation 

## Tests

Navigation test update

## Was this feature tested on all browsers?

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
- [ ] Safari

## Definition of Done

- [ ] README updated
- [ ] Tests written
- [ ] Acceptance criteria implement
- [ ] Code reviewed
- [ ] Feature accepted

## PR Comments Emoji Legend

😻 - `:heart_cat_eyes:` Compliment to code/idea/etc
♻️ - `:recycle:` Non-blocking proposed refactor
➕ - `:heavy_plus_sign:` Non-blocking proposed addition
🔥 - `:fire:` Non-blocking proposed removal
❓ - `:question:` Non-blocking question
⚠️ - `:warning:` Blocking comment that must be addressed before PR


## Gifs for life (required)

![mandatory](https://media.giphy.com/media/pGnQ7i6DuPKmc/giphy-downsized.gif)
